### PR TITLE
use crate redis as protocol parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ edition = "2018"
 
 
 [dependencies]
-net2 = { version = "0.2.2", features = ["nightly"] }
+net2  = { version = "0.2.2", features = ["nightly"] }
 parse = { path = "components/parse" }
+redis = { version = "0.14.0"}
 
 [workspace]
 members = [


### PR DESCRIPTION
# Description

adopt crate "redis" as protocol parser. Reponse serialization is still using "parse". Simplify protocol parsing.

## Type of change

- **Refactoring**

# Checklist:

- [ ] **Style**:       My code follows the **style guidelines** of this project
- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
- [x] **Dep**:         Any **dependent** changes have been merged and published in downstream modules
