### PR TITLE
remove InstIDs. use `repeat InstanceID` instead.

### DIFF
--- a/components/epaxos/src/data/protos/instance.proto
+++ b/components/epaxos/src/data/protos/instance.proto
@@ -21,24 +21,20 @@ message BallotNum {
     int64 replica_id = 3;
 };
 
-message InstIDs {
-    repeated InstanceID ids = 1;
-};
-
 // Instance is the internal representation of a client request.
 message Instance {
 
     // initial_deps is the dependent instance ids when an instance is created.
-    InstIDs initial_deps                = 1;
+    repeated InstanceID initial_deps                = 1;
 
     // deps is the updated instance ids on a replica when handling PreAccept
     // request.
     // When an instance is intiated, it is same as initial_deps.
-    InstIDs deps                        = 2;
+    repeated InstanceID deps                        = 2;
 
     // final_deps is the final dependency chosen by instance leader or recover
     // process, and is set by Accept request or Commit request.
-    InstIDs final_deps                  = 4;
+    repeated InstanceID final_deps                  = 4;
 
     InstanceStatus status               = 21;
     repeated Command cmds               = 31;


### PR DESCRIPTION
It is quite easy to bind methods to `Vec[InstanceID]`,
thus there is no trouble operating instance-ids without introduce
another type.

InstIDs creates a wrapper type:
https://docs.rs/protobuf/2.0.0/protobuf/struct.RepeatedField.html

E.g.:

```
trait Has {
    fn has(&self, i: i64) -> bool;
}
struct InstanceID {
    v: i64,
}

impl Has for Vec<InstanceID> {
    fn has(&self, i:i64) -> bool {
        self[0].v == i
    }
}

impl Has for [InstanceID] {
    fn has(&self, i:i64) -> bool {
        false
    }
}

fn main() {
    let a = vec![InstanceID{v:1}, InstanceID{v:2}];
    println!("{}", a.has(2));

    let b = &[InstanceID{v:1}, InstanceID{v:2}];
    println!("{}", b.has(1));
}
```

## Type of change

<!-- Please delete options that are not relevant. -->

- **Refactoring**


# Checklist:

- [ ] **Style**:       My code follows the **style guidelines** of this project
- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [ ] **Pass**:        New and existing **unit tests pass** locally with my changes
- [ ] **Dep**:         Any **dependent** changes have been merged and published in downstream modules
