### PR TITLE
Pass test without inst ids

### DIFF
--- a/components/epaxos/src/data/protos/instance.proto
+++ b/components/epaxos/src/data/protos/instance.proto
@@ -24,19 +24,22 @@ message BallotNum {
 // Instance is the internal representation of a client request.
 message Instance {
 
+    BallotNum last_ballot  = 11;
+    BallotNum ballot       = 12;
+    InstanceID instance_id = 13;
+    repeated Command cmds  = 21;
+
     // initial_deps is the dependent instance ids when an instance is created.
-    repeated InstanceID initial_deps                = 1;
+    repeated InstanceID initial_deps                = 31;
 
     // deps is the updated instance ids on a replica when handling PreAccept
     // request.
     // When an instance is intiated, it is same as initial_deps.
-    repeated InstanceID deps                        = 2;
+    repeated InstanceID deps                        = 32;
 
     // final_deps is the final dependency chosen by instance leader or recover
     // process, and is set by Accept request or Commit request.
-    repeated InstanceID final_deps                  = 4;
+    repeated InstanceID final_deps                  = 41;
 
-    InstanceStatus status               = 21;
-    repeated Command cmds               = 31;
-    BallotNum ballot                    = 41;
+    InstanceStatus status                           = 51;
 };

--- a/components/epaxos/src/data/protos/message.proto
+++ b/components/epaxos/src/data/protos/message.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "command.proto";
 import "instance.proto";
 
 enum RequestType {
@@ -11,8 +12,8 @@ enum RequestType {
 };
 
 enum MessageType {
-    Request = 0;
-    Reply = 1;
+    TypeRequest = 0;
+    TypeReply = 1;
 };
 
 message Message {
@@ -32,10 +33,11 @@ message Request {
     // 51~60: for commit.
 
     RequestType req_type = 1;
+    int64 to_replica_id = 2;
 
     // Sender's ballot
-    BallotNum ballot = 11;
-    InstanceID instance_id = 12;
+    BallotNum ballot = 12;
+    InstanceID instance_id = 13;
 
     //                                         // required by:
 
@@ -51,14 +53,14 @@ message Reply {
 
     // The ballot stored on acceptor before handling a request.
     BallotNum last_ballot = 11;
-    InstanceID instance_id = 12;
+    InstanceID instance_id = 13;
 
     // deps_status describe what status a dependent instance is in.
     // Only `deps` needs these information in order to commit on fast-path.
 
     //                                         // required by:
 
-    repeated InstanceID     deps        = 31;  // PreAccept,     Prepare
+    repeated InstanceID     deps        = 32;  // PreAccept,     Prepare
     repeated InstanceStatus deps_status = 33;  // PreAccept,
     InstanceStatus          status      = 51;  //                Prepare
 }
@@ -95,7 +97,7 @@ message PreAcceptReply {
     Instance instance = 2;
     bool ok = 3;
     BallotNum ballot = 4;
-    InstIDs committed_deps = 5;
+    repeated InstanceID committed_deps = 5;
 };
 
 // used in Paxos-Accept
@@ -128,7 +130,7 @@ message CommitShort {
     int32 count = 4;
 
     int32 seq = 5;
-    InstIDs deps = 6;
+    repeated InstanceID deps = 6;
 }
 
 message TryPreAcceptReq {

--- a/components/epaxos/src/instance/instance.rs
+++ b/components/epaxos/src/instance/instance.rs
@@ -9,20 +9,6 @@ mod tests;
 
 pub type InstanceIdx = i64;
 
-/// protocol buffer serialized
-// re-export struct InstIDs in data/instance.rs
-pub use data::InstIDs;
-
-impl InstIDs {
-    pub fn new_instance_ids(ids: &[InstanceID]) -> InstIDs {
-        let mut inst_ids = InstIDs::new();
-
-        inst_ids.set_ids(RepeatedField::from_slice(ids));
-
-        return inst_ids;
-    }
-}
-
 // re-export struct OpCode in data/instance.rs
 pub use data::InstanceID;
 
@@ -70,7 +56,7 @@ impl Instance {
         inst.set_status(status);
         inst.set_cmds(RepeatedField::from_slice(cmds));
         inst.set_ballot(ballot.clone());
-        inst.set_initial_deps(InstIDs::new_instance_ids(deps));
+        inst.set_initial_deps(RepeatedField::from_slice(deps));
 
         return inst;
     }

--- a/components/epaxos/src/instance/tests/instance_tests.rs
+++ b/components/epaxos/src/instance/tests/instance_tests.rs
@@ -26,7 +26,7 @@ fn test_instance_protobuf() {
     assert_eq!(inst2.status, status);
     assert_eq!(inst2.cmds.into_vec(), cmds);
     assert_eq!(*inst2.ballot.get_ref(), ballot);
-    for (idx, inst_id) in inst2.initial_deps.get_ref().ids.iter().enumerate() {
+    for (idx, inst_id) in inst2.initial_deps.iter().enumerate() {
         assert_eq!(*inst_id, initial_deps[idx]);
     }
 }

--- a/components/epaxos/src/message/message.rs
+++ b/components/epaxos/src/message/message.rs
@@ -1,6 +1,7 @@
 use super::super::data;
-use super::super::instance::{BallotNum, InstIDs, Instance, InstanceID, InstanceStatus};
+use super::super::instance::{BallotNum, Instance, InstanceID, InstanceStatus};
 use super::super::replica::ReplicaID;
+use protobuf::{RepeatedField};
 
 #[cfg(test)]
 #[path = "./tests/message_tests.rs"]
@@ -29,6 +30,10 @@ pub use data::MessageType;
 /// protocol message wrapper used in transmission
 // re-export struct Message in data/message.rs
 pub use data::Message;
+pub use data::Request;
+pub use data::Reply;
+pub use data::Command;
+
 impl Message {
     // data is moved
     pub fn new_message(req_type: RequestType, msg_type: MessageType, data: Vec<u8>) -> Message {
@@ -135,7 +140,7 @@ impl PreAcceptReply {
         pa_reply.set_instance(inst);
         pa_reply.set_ok(bool::from(ok));
         pa_reply.set_ballot(ballot);
-        pa_reply.set_committed_deps(InstIDs::new_instance_ids(committed_deps));
+        pa_reply.set_committed_deps(RepeatedField::from_slice(committed_deps));
 
         return pa_reply;
     }
@@ -225,7 +230,7 @@ impl CommitShort {
         cs.set_instance_id(inst_id);
         cs.set_count(count);
         cs.set_seq(seq);
-        cs.set_deps(InstIDs::new_instance_ids(deps));
+        cs.set_deps(RepeatedField::from_slice(deps));
 
         return cs;
     }

--- a/components/epaxos/src/message/tests/message_tests.rs
+++ b/components/epaxos/src/message/tests/message_tests.rs
@@ -1,6 +1,9 @@
 use super::*;
-use crate::instance::{BallotNum, InstanceID};
+use crate::instance::{BallotNum, InstanceID, Instance, InstanceStatus};
+use crate::message::{Request, Reply};
+use crate::command::{Command, OpCode};
 use protobuf::{parse_from_bytes, Message};
+use protobuf::{RepeatedField};
 
 #[test]
 fn test_message_protobuf() {
@@ -24,7 +27,7 @@ fn test_message_protobuf() {
     let pr_bytes: Vec<u8> = pr1.write_to_bytes().unwrap();
 
     let req_type = RequestType::Prepare;
-    let msg_type = MessageType::Request;
+    let msg_type = MessageType::TypeRequest;
 
     let msg1 = super::Message::new_message(req_type, msg_type, pr_bytes);
     let size = msg1.compute_size();

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -3,7 +3,8 @@ use std::thread::JoinHandle;
 
 use super::super::command::Command;
 use super::super::conf::ClusterInfo;
-use super::super::instance::{InstIDs, Instance, InstanceID, InstanceIdx};
+use super::super::instance::{Instance, InstanceID, InstanceIdx};
+
 use super::super::message::*;
 
 #[cfg(test)]
@@ -51,9 +52,9 @@ pub struct Replica {
     pub smr: SMR, // state machine replication
 
     pub inst_idx: InstanceIdx,
-    pub crt_inst: InstIDs, // highest active instance numbers that this replica knows
-    pub replica_committed: InstIDs, // highest continuous committed instance per replica that known
-    pub replica_executed: InstIDs, // highest executed instance per replica that known
+    // pub crt_inst: InstIDs, // highest active instance numbers that this replica knows
+    // pub replica_committed: InstIDs, // highest continuous committed instance per replica that known
+    // pub replica_executed: InstIDs, // highest executed instance per replica that known
 
     // TODO(lsl): get exec thread handle from @baohai
     pub exec_worker: JoinHandle<()>, // handle of exec thread


### PR DESCRIPTION
# Description

### fix protobuf ops to pass test without instIDs.
- Use uniform field index.

- Rename Message.Request to Message.TypeRequest and so is
    Message.TypeReply, for the upcoming Request and Reply message.

- Comment out several fields in struct Replica.


### built protobuf file change

## Type of change

<!-- Please delete options that are not relevant. -->

- **Refactoring**
- **Test changes**


# Checklist:

- [ ] **Style**:       My code follows the **style guidelines** of this project
- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
- [ ] **Dep**:         Any **dependent** changes have been merged and published in downstream modules
