### PR TITLE
use rust yaml to parse cluster conf

### DIFF
--- a/components/epaxos/Cargo.toml
+++ b/components/epaxos/Cargo.toml
@@ -24,6 +24,8 @@ tonic = "0.1"
 tokio = { version = "0.2", features = ["macros"] }
 derive_more = "0.99.3"
 num = "0.2.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = { version = "0.8" }
 
 [build-dependencies]
 tonic-build = "0.1.0"

--- a/components/epaxos/src/conf/conf.rs
+++ b/components/epaxos/src/conf/conf.rs
@@ -1,5 +1,11 @@
-use std::collections::HashMap;
-use std::net::IpAddr;
+use std::collections::BTreeMap;
+use std::fs;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use super::errors::ConfError;
+
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 #[path = "./tests/conf_tests.rs"]
@@ -8,13 +14,36 @@ mod tests;
 pub type NodeID = String;
 
 /// a struct to represent a cluster node, not necessary a replica
+#[derive(Serialize, Deserialize, Debug)]
 pub struct NodeInfo {
+    #[serde(default)]
     pub node_id: NodeID,
-    pub ip: IpAddr,
+    pub api_addr: SocketAddr,
+    pub api_uaddr: Option<String>,
+    pub replication: SocketAddr,
     // idc: String, // TODO(lsl): need topology information of a node
 }
 
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ClusterInfo {
-    // pub nodes: Vec<NodeInfo>,
-    pub nodes: HashMap<NodeID, NodeInfo>,
+    pub nodes: BTreeMap<String, NodeInfo>,
+}
+
+impl ClusterInfo {
+    pub fn new(path: &PathBuf) -> Result<ClusterInfo, ConfError> {
+        let content = fs::read_to_string(path)?;
+        let mut cluster: ClusterInfo = serde_yaml::from_str(content.as_str())?;
+
+        for (_, node) in cluster.nodes.iter_mut() {
+            node.node_id = ClusterInfo::make_node_id("");
+        }
+
+        return Ok(cluster);
+    }
+
+    // make a node id from key, i.e. mac address
+    pub fn make_node_id(_: &str) -> NodeID {
+        // TODO: make sure the way to make node id
+        return String::from("");
+    }
 }

--- a/components/epaxos/src/conf/errors.rs
+++ b/components/epaxos/src/conf/errors.rs
@@ -1,0 +1,10 @@
+quick_error! {
+    #[derive(Debug)]
+    pub enum ConfError {
+        Error{s: String} {
+            from(err: std::io::Error) -> {s: format!("IO Error: {}", err)}
+            from(err: serde_yaml::Error) -> {s: format!("Yaml Error: {}", err)}
+        }
+    }
+}
+//from(err: std::io::Error) -> (format!("IO Error: {:?}", err))

--- a/components/epaxos/src/conf/mod.rs
+++ b/components/epaxos/src/conf/mod.rs
@@ -1,3 +1,5 @@
 mod conf;
+mod errors;
 
 pub use self::conf::*;
+pub use errors::*;

--- a/components/epaxos/src/conf/tests/conf_tests.rs
+++ b/components/epaxos/src/conf/tests/conf_tests.rs
@@ -1,6 +1,54 @@
 use super::*;
+use std::fs::File;
+use std::io::Write;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::str::FromStr;
 
 #[test]
-fn test_conf() {
-    println!("lsl-debug: conf_tests");
+fn test_conf_serde_yaml() {
+    // create tmp yaml file
+    let content = "
+nodes:
+    127.0.0.1:3331:
+        api_addr: 127.0.0.1:3331
+        replication: 127.0.0.1:4441
+    192.168.0.1:3332:
+        api_addr: 192.168.0.1:3332
+        api_uaddr: /var/run/usocket2
+        replication: 192.168.0.1:4442
+        ";
+
+    let pb = PathBuf::from("/tmp/conf.yaml");
+    let mut writer = File::create(&pb).unwrap();
+    writer.write_all(content.as_bytes()).unwrap();
+    writer.sync_all().unwrap();
+
+    // test `new`
+    let ci = ClusterInfo::new(&pb).unwrap();
+    assert_eq!(2, ci.nodes.len());
+
+    let n1_key = "127.0.0.1:3331";
+    let n2_key = "192.168.0.1:3332";
+
+    // test `get`
+    let n1 = ci.nodes.get(n1_key).unwrap();
+    assert_eq!("", n1.node_id);
+    assert_eq!(SocketAddr::from_str(n1_key).unwrap(), n1.api_addr);
+    assert_eq!(
+        SocketAddr::from_str("127.0.0.1:4441").unwrap(),
+        n1.replication
+    );
+    assert_eq!(true, n1.api_uaddr.is_none());
+
+    let n2 = ci.nodes.get(n2_key).unwrap();
+    assert_eq!("", n2.node_id);
+    assert_eq!(SocketAddr::from_str(n2_key).unwrap(), n2.api_addr);
+    assert_eq!(
+        SocketAddr::from_str("192.168.0.1:4442").unwrap(),
+        n2.replication
+    );
+    assert_eq!("/var/run/usocket2", n2.api_uaddr.as_ref().unwrap());
+
+    fs::remove_file(pb).unwrap();
 }


### PR DESCRIPTION
# Description
parse cluster conf from yaml to ClusterInfo struct

Fixes # (https://github.com/openacid/celeritasdb/issues/110)

## Type of change

- **New feature**     <!-- non-breaking change which adds functionality -->

# Checklist:

- [x] **Style**:       My code follows the **style guidelines** of this project
- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
- [ ] **Dep**:         Any **dependent** changes have been merged and published in downstream modules
