### PR TITLE
replica exec impl find missing instances

### DIFF
--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -1,1 +1,51 @@
+use crate::instance::Instance;
+use crate::instance::InstanceID;
+use crate::replica::Replica;
 
+#[cfg(test)]
+#[path = "./tests/exec_tests.rs"]
+mod tests;
+
+impl<Engine> Replica<Engine> {
+    // R1          R2
+    // -------------
+    // |           |
+    // d(NotFound) |
+    // | ↖ ........b(Committed)
+    // a(Executed) |
+    //
+    // instances((a, d]) not exist in this replica, recover instance(a+1) first
+    fn find_missing_insts(
+        &self,
+        min_insts: &Vec<Instance>,
+        exec_up_to: &Vec<InstanceID>,
+    ) -> Option<Vec<InstanceID>> {
+        let mut rst = Vec::new();
+
+        for inst in min_insts {
+            for dep_inst_id in inst.final_deps.iter() {
+                if let Some(_) = min_insts.iter().find(|x| match &x.instance_id {
+                    Some(iid) => return iid.replica_id == dep_inst_id.replica_id,
+                    None => return false,
+                }) {
+                    continue;
+                }
+
+                if let Some(iid) = exec_up_to
+                    .iter()
+                    .find(|&x| x.replica_id == dep_inst_id.replica_id)
+                {
+                    if dep_inst_id.idx > iid.idx {
+                        rst.push(InstanceID::of(iid.replica_id, iid.idx + 1));
+                    }
+                }
+            }
+        }
+
+        if rst.len() > 0 {
+            return Some(rst);
+        }
+
+        None
+    }
+}

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -25,6 +25,7 @@ pub struct ReplicaPeer {
 }
 
 /// misc configuration info
+#[derive(Default)]
 pub struct ReplicaConf {
     pub thrifty: bool,        // send msg only to a quorum or the full set
     pub exec: bool,           // exec comamnd or not
@@ -41,9 +42,6 @@ pub enum ReplicaStatus {
     Down,
 }
 
-// TODO(lsl): use defination from @yipu
-pub struct SMR {}
-
 /// structure to represent a replica
 pub struct Replica<Engine> {
     pub replica_id: ReplicaID,             // replica id
@@ -54,23 +52,11 @@ pub struct Replica<Engine> {
     pub peers: Vec<ReplicaPeer>, // peers in communication, if need access from multi-thread, wrap it by Arc<>
     pub conf: ReplicaConf,       // misc conf
 
-    pub smr: SMR, // state machine replication
-
     pub inst_idx: InstanceIdx,
-    // pub crt_inst: InstIDs, // highest active instance numbers that this replica knows
-    // pub replica_committed: InstIDs, // highest continuous committed instance per replica that known
-    // pub replica_executed: InstIDs, // highest executed instance per replica that known
+    pub latest_cp: InstanceID, // record the instance id in the lastest communication
 
-    // TODO(lsl): get exec thread handle from @baohai
-    pub exec_worker: JoinHandle<()>, // handle of exec thread
-    pub max_seq: i64,                // max seq ever known in cluster
-    pub latest_cp: InstanceID,       // record the instance id in the lastest communication
-
-    // snapshot trait
-    pub inst_engine: Box<dyn InstanceEngine<Engine>>,
-    pub kv_engine: Box<dyn KVEngine>,
-    pub st_engine: Box<dyn StatusEngine>,
-    pub tran_engine: Box<dyn TransactionEngine<Engine>>,
+    // snapshot engine
+    pub engine: Engine,
 
     // to recover uncommitted instance
     pub problem_inst_ids: Vec<(InstanceID, SystemTime)>,

--- a/components/epaxos/src/replica/tests/exec_tests.rs
+++ b/components/epaxos/src/replica/tests/exec_tests.rs
@@ -1,0 +1,159 @@
+use std::net::{SocketAddr, TcpListener, TcpStream};
+
+use crate::instance::Instance;
+use crate::instance::InstanceID;
+use crate::replica::Replica;
+use crate::replica::ReplicaConf;
+use crate::replica::ReplicaStatus;
+use crate::snapshot::MemEngine;
+
+fn new_replica() -> Replica<MemEngine> {
+    return Replica {
+        replica_id: 0,
+        group_replica_ids: vec![],
+        status: ReplicaStatus::Running,
+        client_listener: TcpListener::bind("127.0.0.1:5001").unwrap(),
+        listener: TcpListener::bind("127.0.0.1:6001").unwrap(),
+        peers: vec![],
+        conf: ReplicaConf {
+            ..Default::default()
+        },
+        inst_idx: 0,
+        latest_cp: InstanceID::of(1, 1),
+        engine: MemEngine::new().unwrap(),
+        problem_inst_ids: vec![],
+    };
+}
+
+#[test]
+fn test_find_missing_instances() {
+    let rp = new_replica();
+
+    let cases1 = [
+        (
+            vec![Instance {
+                instance_id: Some(InstanceID::of(1, 2)),
+                final_deps: vec![InstanceID::of(1, 1)],
+                ..Default::default()
+            }],
+            vec![InstanceID::of(1, 1)],
+        ),
+        // R1               R2              R3
+        // |                |               |
+        // |                2(Committed)-.  10(Executed)
+        // |                |             ↘ |
+        // 2(Committed)--.---------------.  5
+        // |              ↘ |             ↘ |
+        // 1(Executed)      1(Executed)     3
+        // |                |               |
+        (
+            vec![
+                Instance {
+                    instance_id: Some(InstanceID::of(1, 2)),
+                    final_deps: vec![
+                        InstanceID::of(1, 1),
+                        InstanceID::of(2, 1),
+                        InstanceID::of(3, 3),
+                    ],
+                    ..Default::default()
+                },
+                Instance {
+                    instance_id: Some(InstanceID::of(2, 2)),
+                    final_deps: vec![
+                        InstanceID::of(1, 1),
+                        InstanceID::of(2, 1),
+                        InstanceID::of(3, 5),
+                    ],
+                    ..Default::default()
+                },
+            ],
+            vec![
+                InstanceID::of(1, 1),
+                InstanceID::of(2, 1),
+                InstanceID::of(3, 10),
+            ],
+        ),
+    ];
+
+    for (insts, up_to) in cases1.iter() {
+        match rp.find_missing_insts(&insts, &up_to) {
+            None => assert!(true),
+            Some(s) => assert!(false),
+        };
+    }
+
+    let case2 = [
+        // R1               R2              R3
+        // |                |               |
+        // |                6(NotFound)    6(NotFound)
+        // |              ↗ |             ↗ |
+        // 2(Committed)--`---------------`  |
+        // |                |               |
+        // 1(Executed)      5(Executed)     5(Executed)
+        // |                |               |
+        //
+        // need recover (2, 6) and (3, 6)
+        (
+            vec![Instance {
+                instance_id: Some(InstanceID::of(1, 2)),
+                final_deps: vec![
+                    InstanceID::of(1, 1),
+                    InstanceID::of(2, 6),
+                    InstanceID::of(3, 6),
+                ],
+                ..Default::default()
+            }],
+            vec![
+                InstanceID::of(1, 1),
+                InstanceID::of(2, 5),
+                InstanceID::of(3, 5),
+            ],
+            vec![InstanceID::of(2, 6), InstanceID::of(3, 6)],
+        ),
+        // R1               R2              R3
+        // |                |               |
+        // |      .---------2-------------→ 3(NotFound)
+        // |    .`          |               |
+        // 2(Committed)--.---------------.  2(NotFound)
+        // |↙             ↘ |             ↘ |
+        // 1(Executed)      1(Executed)     1(Executed)
+        // |                |               |
+        //
+        // need recover (3, 2)
+        (
+            vec![
+                Instance {
+                    instance_id: Some(InstanceID::of(1, 2)),
+                    final_deps: vec![
+                        InstanceID::of(1, 1),
+                        InstanceID::of(2, 1),
+                        InstanceID::of(3, 1),
+                    ],
+                    ..Default::default()
+                },
+                Instance {
+                    instance_id: Some(InstanceID::of(2, 2)),
+                    final_deps: vec![
+                        InstanceID::of(1, 1),
+                        InstanceID::of(2, 1),
+                        InstanceID::of(3, 3),
+                    ],
+                    ..Default::default()
+                },
+            ],
+            vec![
+                InstanceID::of(1, 1),
+                InstanceID::of(2, 1),
+                InstanceID::of(3, 1),
+            ],
+            vec![InstanceID::of(3, 2)],
+        ),
+    ];
+
+    for (insts, up_to, exp) in case2.iter() {
+        match rp.find_missing_insts(&insts, &up_to) {
+            None => assert!(false),
+            Some(s) => assert_eq!(exp, &s),
+        };
+    }
+}


### PR DESCRIPTION
# Description

R2自己认为R1上没有instance可以exec，实际上是可能有需要exec的instance，这个时候就需要recover R1上的instance，然后再exec。

例如在R2上看到的Instance Space如下：
```
R1          R2
-------------
|           |
d(NotFound) |
| ↖ ........b(Committed)
a(Executed) |
                                                                         
instances((a, d]) not exist in this replica, recover instance(a+1) first
```

- R1上没有instance可exec
- R2上找到一个b需要exec
- 由于b→d(not found in R1)
- 这个时候R1(a, d]这个区间的instances是缺失的
- recover R1(a+1)，然后再选择每个replica最小的instance执行

## Type of change

<!-- Please delete options that are not relevant. -->

- **New feature**     <!-- non-breaking change which adds functionality -->

# Checklist:

- [x] **Style**:       My code follows the **style guidelines** of this project
- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
- [ ] **Dep**:         Any **dependent** changes have been merged and published in downstream modules
