### PR TITLE
feat: derive Copy and From for simple datatypes

### DIFF
--- a/components/epaxos/Cargo.toml
+++ b/components/epaxos/Cargo.toml
@@ -22,6 +22,7 @@ tempfile = { version = "3.1.0" }
 prost = { version = "0.6.1" }
 tonic = "0.1"
 tokio = { version = "0.2", features = ["macros"] }
+derive_more = "0.99.3"
 
 [build-dependencies]
 tonic-build = "0.1.0"

--- a/components/epaxos/build.rs
+++ b/components/epaxos/build.rs
@@ -6,6 +6,10 @@ fn main() {
     tonic_build::configure()
         .build_client(true)
         .build_server(true)
+        //TODO command contains vec<u8> that can not be copied.
+        // .type_attribute("Command", "#[derive(Copy)]")
+        .type_attribute("InstanceID", "#[derive(Copy, derive_more::From)]")
+        .type_attribute("BallotNum", "#[derive(Copy, derive_more::From)]")
         .compile(
             &[
                 "src/protos/command.proto",

--- a/components/epaxos/src/instance/mod.rs
+++ b/components/epaxos/src/instance/mod.rs
@@ -1,6 +1,7 @@
 use super::command::Command;
 use super::tokey::ToKey;
 use std::cmp::{Ord, Ordering};
+use derive_more;
 
 include!(concat!(env!("OUT_DIR"), "/instance.rs"));
 

--- a/components/epaxos/src/instance/mod.rs
+++ b/components/epaxos/src/instance/mod.rs
@@ -1,7 +1,7 @@
 use super::command::Command;
 use super::tokey::ToKey;
-use std::cmp::{Ord, Ordering};
 use derive_more;
+use std::cmp::{Ord, Ordering};
 
 include!(concat!(env!("OUT_DIR"), "/instance.rs"));
 

--- a/components/epaxos/src/instance/tests/instance_tests.rs
+++ b/components/epaxos/src/instance/tests/instance_tests.rs
@@ -22,7 +22,6 @@ fn test_instance_protobuf() {
 
 #[test]
 fn test_instanceid_derived() {
-
     let inst_id1 = InstanceID::of(1, 10);
     let inst_id2 = inst_id1;
 
@@ -32,7 +31,6 @@ fn test_instanceid_derived() {
 
 #[test]
 fn test_ballotnum_derived() {
-
     let b1 = BallotNum::of(1, 10, 5);
     let b2 = b1;
 
@@ -69,8 +67,8 @@ fn test_cmp_instance_id() {
     ];
 
     for (t1, t2, op) in cases {
-        let i1 :InstanceID = t1.into();
-        let i2 :InstanceID = t2.into();
+        let i1: InstanceID = t1.into();
+        let i2: InstanceID = t2.into();
         match op {
             "=" => assert_eq!(i1 == i2, true),
             "<=" => assert_eq!(i1 <= i2, true),
@@ -133,11 +131,7 @@ fn test_instance_after() {
         ),
         (
             Instance {
-                final_deps: vec![
-                    (1, 1).into(),
-                    (2, 1).into(),
-                    (3, 1).into(),
-                ],
+                final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 1).into()],
                 ..Default::default()
             },
             Instance {
@@ -152,11 +146,7 @@ fn test_instance_after() {
                 ..Default::default()
             },
             Instance {
-                final_deps: vec![
-                    (1, 1).into(),
-                    (2, 1).into(),
-                    (3, 1).into(),
-                ],
+                final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 1).into()],
                 ..Default::default()
             },
             false,
@@ -167,11 +157,7 @@ fn test_instance_after() {
                 ..Default::default()
             },
             Instance {
-                final_deps: vec![
-                    (1, 1).into(),
-                    (2, 1).into(),
-                    (3, 1).into(),
-                ],
+                final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 1).into()],
                 ..Default::default()
             },
             true,


### PR DESCRIPTION
- feat: add "dervie Copy" for basic types.
- feat: use derive_more to make creating struct more easily
- refactor: simplify instanceID test with into()


## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**

<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
