### PR TITLE
feat: generate PartialOrd etc, remove manually impl

### DIFF
--- a/components/epaxos/build.rs
+++ b/components/epaxos/build.rs
@@ -8,10 +8,14 @@ fn main() {
         .build_server(true)
         //TODO command contains vec<u8> that can not be copied.
         // .type_attribute("Command", "#[derive(Copy)]")
-        .type_attribute("InstanceID",
-                        "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]")
-        .type_attribute("BallotNum",
-                        "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]")
+        .type_attribute(
+            "InstanceID",
+            "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]",
+        )
+        .type_attribute(
+            "BallotNum",
+            "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]",
+        )
         .compile(
             &[
                 "src/protos/command.proto",

--- a/components/epaxos/build.rs
+++ b/components/epaxos/build.rs
@@ -8,8 +8,10 @@ fn main() {
         .build_server(true)
         //TODO command contains vec<u8> that can not be copied.
         // .type_attribute("Command", "#[derive(Copy)]")
-        .type_attribute("InstanceID", "#[derive(Copy, derive_more::From)]")
-        .type_attribute("BallotNum", "#[derive(Copy, derive_more::From)]")
+        .type_attribute("InstanceID",
+                        "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]")
+        .type_attribute("BallotNum",
+                        "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]")
         .compile(
             &[
                 "src/protos/command.proto",

--- a/components/epaxos/src/protos/README.md
+++ b/components/epaxos/src/protos/README.md
@@ -1,38 +1,8 @@
 ## Introduction
 
-all proto files and generated files are placed here.
-
-and ** DO NOT USE THIS MODULE DIRECTLY **
+all proto files for qpaxos protocol.
 
 ## Usage
 
-### Prepare
-
-create `protobuf-gen-rust` under `celeritasdb/components/protobuf-gen-rust`.
-
-Place the executable binary named protobuf-gen-rust under the directory in your
-`PATH`.
-
-### generate all protos once
-
-go to path `celeritasdb/components/epaxos/src/data`
-
-```
-protobuf-gen-rust -o ./ -s protos
-```
-
-the generated rs files would be placed under `celeritasdb/components/epaxos/src/data`.
-
-### generate specified protos only
-
-go to path `celeritasdb/components/epaxos/src/data`
-
-```
-protobuf-gen-rust -o ./ -s protos -f command.proto
-```
-
-the result is the same as above.
-
-### update mod.rs under `celeritasdb/components/epaxos/src/data`
-
-re-export your new module in mod.rs.
+`*.proto`s are built by `build.rs`.
+The generated rs files can be found in `target/**/out`. Just `find` it.

--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -3,7 +3,6 @@ use tonic::{Request, Response, Status};
 
 use super::tokey::ToKey;
 use derive_more;
-use std::cmp::{Ord, Ordering};
 
 include!(concat!(env!("OUT_DIR"), "/qpaxos.rs"));
 
@@ -38,26 +37,6 @@ impl ToKey for InstanceID {
     }
 }
 
-impl Eq for InstanceID {}
-
-impl Ord for InstanceID {
-    fn cmp(&self, other: &Self) -> Ordering {
-        let _ = match self.replica_id.cmp(&other.replica_id) {
-            Ordering::Greater => return Ordering::Greater,
-            Ordering::Less => return Ordering::Less,
-            Ordering::Equal => Ordering::Equal,
-        };
-
-        self.idx.cmp(&other.idx)
-    }
-}
-
-impl PartialOrd for InstanceID {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 impl InstanceID {
     pub fn of(replica_id: i64, idx: i64) -> InstanceID {
         InstanceID {
@@ -88,17 +67,6 @@ impl InstanceID {
         }
 
         return None;
-    }
-}
-
-impl BallotNum {
-    pub fn of(epoch: i32, num: i32, replica_id: i64) -> BallotNum {
-        BallotNum {
-            epoch,
-            num,
-            replica_id,
-            ..Default::default()
-        }
     }
 }
 

--- a/components/epaxos/src/qpaxos/t.rs
+++ b/components/epaxos/src/qpaxos/t.rs
@@ -15,8 +15,8 @@ fn new_foo_inst() -> Instance {
     let cmd1 = Command::of(OpCode::NoOp, "k1".as_bytes(), "v1".as_bytes());
     let cmd2 = Command::of(OpCode::Get, "k2".as_bytes(), "v2".as_bytes());
     let cmds = vec![cmd1, cmd2];
-    let ballot = BallotNum::of(0, 0, replica);
-    let ballot2 = BallotNum::of(1, 2, replica);
+    let ballot = (0, 0, replica).into();
+    let ballot2 = (1, 2, replica).into();
 
     let mut inst = Instance::of(&cmds[..], &ballot, &initial_deps[..]);
     // TODO move these to Instance::new_instance
@@ -72,7 +72,7 @@ fn test_instanceid_derived() {
 
 #[test]
 fn test_ballotnum_derived() {
-    let b1 = BallotNum::of(1, 10, 5);
+    let b1 = BallotNum::from((1, 10, 5));
     let b2 = b1;
 
     assert_eq!(b1, b2);

--- a/components/epaxos/src/snapshot/memEngine/memdb.rs
+++ b/components/epaxos/src/snapshot/memEngine/memdb.rs
@@ -65,7 +65,7 @@ impl InstanceEngine<MemEngine> for MemEngine {
             Ok(v) => v,
             Err(err) => {
                 if err == Error::NotFound {
-                    InstanceID::of(iid.replica_id, -1)
+                    InstanceID::from((iid.replica_id, -1))
                 } else {
                     return Err(err);
                 }
@@ -102,7 +102,7 @@ impl InstanceEngine<MemEngine> for MemEngine {
     }
 
     fn get_instance_iter(&self, rid: ReplicaID) -> Result<InstanceIter<MemEngine>, Error> {
-        let iid = InstanceID::of(rid.clone(), 0);
+        let iid = InstanceID::from((rid, 0));
         Ok(InstanceIter {
             curr_inst_id: iid,
             include: true,
@@ -179,7 +179,7 @@ mod tests {
 
         for rid in 0..3 {
             for idx in 0..10 {
-                let iid = InstanceID::of(rid, idx);
+                let iid = InstanceID::from((rid, idx));
 
                 let cmds = vec![Command::of(
                     OpCode::NoOp,
@@ -187,9 +187,9 @@ mod tests {
                     format!("v1{:}", rid * idx).as_bytes(),
                 )];
 
-                let ballot = BallotNum::of(rid as i32, idx as i32, 0);
+                let ballot = (rid as i32, idx as i32, 0).into();
 
-                let deps = vec![InstanceID::of(rid + 1, idx + 1)];
+                let deps = vec![InstanceID::from((rid + 1, idx + 1))];
 
                 let inst = Instance::of(&cmds[..], &ballot, &deps[..]);
 
@@ -239,7 +239,7 @@ mod tests {
         for (rid, idx) in cases {
             let mut engine = MemEngine::new().unwrap();
 
-            let iid = InstanceID::of(rid, idx);
+            let iid = InstanceID::from((rid, idx));
 
             let key = engine.max_instance_id_key(rid);
             let _ = engine.set_instance_id(&key, iid.clone()).unwrap();


### PR DESCRIPTION
- refactor: remove BallotNum::of. use auto-generated ::from instead

- fix: protos README.md

## Type of change       <!-- delete irrelevant options. -->


- **Refactoring**

<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
