### PR TITLE
refactor: simplify reference usage

### DIFF
--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -62,7 +62,7 @@ impl<E> Replica<E> {
             if OpCode::NoOp as i32 == cmd.op {
                 rst.push(ExecuteResult::Success);
             } else if OpCode::Set as i32 == cmd.op {
-                self.storage.set_kv(&cmd.key, &cmd.value)?;
+                self.storage.set_kv(cmd.key.clone(), cmd.value.clone())?;
                 rst.push(ExecuteResult::Success);
             } else if OpCode::Get as i32 == cmd.op {
                 match self.storage.get_kv(&cmd.key) {
@@ -80,7 +80,7 @@ impl<E> Replica<E> {
         let mut new_inst = inst.clone();
         new_inst.executed = true;
         self.storage
-            .update_instance(&inst.instance_id.unwrap(), new_inst)?;
+            .update_instance(inst.instance_id.unwrap(), new_inst)?;
 
         Ok(rst)
     }

--- a/components/epaxos/src/replica/tests/exec_tests.rs
+++ b/components/epaxos/src/replica/tests/exec_tests.rs
@@ -127,11 +127,11 @@ fn test_find_missing_instances() {
 fn test_execute_commands() {
     let mut rp = new_replica();
 
-    match rp.storage.set_kv(&vec![1], &vec![11]) {
+    match rp.storage.set_kv(vec![1], vec![11]) {
         Err(_) => assert!(false),
         Ok(_) => {}
     }
-    match rp.storage.set_kv(&vec![2], &vec![22]) {
+    match rp.storage.set_kv(vec![2], vec![22]) {
         Err(_) => assert!(false),
         Ok(_) => {}
     }

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -9,7 +9,7 @@ use super::InstanceIter;
 /// KVEngine offer functions to operate snapshot key-values
 pub trait KVEngine {
     /// set a new key-value
-    fn set_kv(&mut self, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), Error>;
+    fn set_kv(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
     /// get an existing value with key
     fn get_kv(&self, key: &Vec<u8>) -> Result<Vec<u8>, Error>;
 }
@@ -17,9 +17,9 @@ pub trait KVEngine {
 /// InstanceEngine offer functions to operate snapshot instances
 pub trait InstanceEngine<T>: KVEngine {
     /// set a new instance
-    fn set_instance(&mut self, iid: &InstanceID, inst: Instance) -> Result<(), Error>;
+    fn set_instance(&mut self, iid: InstanceID, inst: Instance) -> Result<(), Error>;
     /// update an existing instance with instance id
-    fn update_instance(&mut self, iid: &InstanceID, inst: Instance) -> Result<(), Error>;
+    fn update_instance(&mut self, iid: InstanceID, inst: Instance) -> Result<(), Error>;
     /// get an instance with instance id
     fn get_instance(&self, iid: &InstanceID) -> Result<Instance, Error>;
     /// get an iterator to scan all instances with a leader replica id
@@ -42,10 +42,10 @@ pub trait StatusEngine: KVEngine {
         format!("/status/max_exec_instance_id/{:x}", rid).into_bytes()
     }
 
-    fn set_instance_id(&mut self, key: &Vec<u8>, iid: InstanceID) -> Result<(), Error> {
+    fn set_instance_id(&mut self, key: Vec<u8>, iid: InstanceID) -> Result<(), Error> {
         let mut value = vec![];
         iid.encode(&mut value).unwrap();
-        self.set_kv(&key, &value)
+        self.set_kv(key, value)
     }
 }
 


### PR DESCRIPTION
Rules:
-   If a function consumes a variable, it moves the var.
    It is the caller's responsibility to clone it before re-using a var
    after calling the function.

-   If a function does not consume a variable, the parameter should be
    a reference to the var.

-   Fixed size var always pass value instead of reference for
    simplicity, if there is not performance issue with it.


## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
