### PR TITLE
adjust engine traits

### DIFF
--- a/components/epaxos/Cargo.toml
+++ b/components/epaxos/Cargo.toml
@@ -23,6 +23,7 @@ prost = { version = "0.6.1" }
 tonic = "0.1"
 tokio = { version = "0.2", features = ["macros"] }
 derive_more = "0.99.3"
+num = "0.2.1"
 
 [build-dependencies]
 tonic-build = "0.1.0"

--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -13,7 +13,7 @@ pub enum ExecuteResult {
     NotFound,
 }
 
-impl<E> Replica<E> {
+impl Replica {
     // R1          R2
     // -------------
     // |           |

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -5,7 +5,7 @@ use super::super::conf::ClusterInfo;
 
 use super::super::qpaxos::*;
 
-use super::super::snapshot::TransactionEngine;
+use super::super::snapshot::TxEngine;
 
 #[cfg(test)]
 #[path = "./tests/replica_tests.rs"]
@@ -53,7 +53,7 @@ pub struct Replica<E> {
     pub latest_cp: InstanceID, // record the instance id in the lastest communication
 
     // storage
-    pub storage: Box<dyn TransactionEngine<E>>,
+    pub storage: Box<dyn TxEngine<E>>,
 
     // to recover uncommitted instance
     pub problem_inst_ids: Vec<(InstanceID, SystemTime)>,

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -5,7 +5,7 @@ use super::super::conf::ClusterInfo;
 
 use super::super::qpaxos::*;
 
-use super::super::snapshot::TxEngine;
+use super::super::snapshot::{InstanceEngine, StatusEngine, TxEngine};
 
 #[cfg(test)]
 #[path = "./tests/replica_tests.rs"]
@@ -40,7 +40,7 @@ pub enum ReplicaStatus {
 }
 
 /// structure to represent a replica
-pub struct Replica<E> {
+pub struct Replica {
     pub replica_id: ReplicaID,             // replica id
     pub group_replica_ids: Vec<ReplicaID>, // all replica ids in this group
     pub status: ReplicaStatus,             // status record used internally
@@ -53,13 +53,13 @@ pub struct Replica<E> {
     pub latest_cp: InstanceID, // record the instance id in the lastest communication
 
     // storage
-    pub storage: Box<dyn TxEngine<E>>,
+    pub storage: Box<dyn InstanceEngine<RID = ReplicaID, Item = InstanceID>>,
 
     // to recover uncommitted instance
     pub problem_inst_ids: Vec<(InstanceID, SystemTime)>,
 }
 
-impl<E> Replica<E> {
+impl Replica {
     /// create a new Replica
     /// do all the initialization and start all necessary threads here,
     /// so after this call, replica is fully functional.
@@ -69,7 +69,7 @@ impl<E> Replica<E> {
         thrifty: bool,
         exec: bool,
         beacon: bool,
-    ) -> Result<Replica<E>, String> {
+    ) -> Result<Replica, String> {
         Err("not implemented".to_string())
     }
 

--- a/components/epaxos/src/replica/tests/exec_tests.rs
+++ b/components/epaxos/src/replica/tests/exec_tests.rs
@@ -4,7 +4,7 @@ use crate::qpaxos::{Command, Instance, InstanceID, OpCode};
 use crate::replica::{ExecuteResult, Replica, ReplicaConf, ReplicaStatus};
 use crate::snapshot::MemEngine;
 
-fn new_replica() -> Replica<MemEngine> {
+fn new_replica() -> Replica {
     return Replica {
         replica_id: 0,
         group_replica_ids: vec![],

--- a/components/epaxos/src/snapshot/iters.rs
+++ b/components/epaxos/src/snapshot/iters.rs
@@ -13,6 +13,7 @@ pub struct InstanceIter<'a, T> {
 impl<'a> Iterator for InstanceIter<'a, MemEngine> {
     type Item = Instance;
 
+    // TODO add unittest. now the only test for this is in mem_engine.
     fn next(&mut self) -> Option<Instance> {
         let k = self.curr_inst_id.to_key();
         let (key_bytes, val_bytes) = self.engine.next_kv(&k, self.include)?;

--- a/components/epaxos/src/snapshot/iters.rs
+++ b/components/epaxos/src/snapshot/iters.rs
@@ -1,16 +1,16 @@
-use super::mem_engine::*;
+use super::traits::*;
 use crate::qpaxos::{Instance, InstanceID};
 use prost::Message;
 
 use crate::tokey::ToKey;
 
-pub struct InstanceIter<'a, T> {
+pub struct InstanceIter<'a> {
     pub curr_inst_id: InstanceID,
     pub include: bool,
-    pub engine: &'a T,
+    pub engine: &'a dyn Base,
 }
 
-impl<'a> Iterator for InstanceIter<'a, MemEngine> {
+impl<'a> Iterator for InstanceIter<'a> {
     type Item = Instance;
 
     // TODO add unittest. now the only test for this is in mem_engine.

--- a/components/epaxos/src/snapshot/mem_engine/memdb.rs
+++ b/components/epaxos/src/snapshot/mem_engine/memdb.rs
@@ -5,7 +5,7 @@ use super::MemEngine;
 use prost::Message;
 
 use super::super::{
-    Error, InstanceEngine, InstanceIter, KVEngine, StatusEngine, TransactionEngine,
+    Error, InstanceEngine, InstanceIter, Base, StatusEngine, TransactionEngine,
 };
 use crate::qpaxos::{BallotNum, Instance, InstanceID};
 use crate::qpaxos::{Command, OpCode};
@@ -35,7 +35,7 @@ impl MemEngine {
     }
 }
 
-impl KVEngine for MemEngine {
+impl Base for MemEngine {
     fn set_kv(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
         self._db.insert(key, value);
         Ok(())

--- a/components/epaxos/src/snapshot/mem_engine/memdb.rs
+++ b/components/epaxos/src/snapshot/mem_engine/memdb.rs
@@ -5,7 +5,7 @@ use super::MemEngine;
 use prost::Message;
 
 use super::super::{
-    Error, InstanceEngine, InstanceIter, Base, StatusEngine, TransactionEngine,
+    Error, InstanceEngine, InstanceIter, Base, StatusEngine, TxEngine,
 };
 use crate::qpaxos::{BallotNum, Instance, InstanceID};
 use crate::qpaxos::{Command, OpCode};
@@ -137,7 +137,7 @@ impl StatusEngine for MemEngine {
     }
 }
 
-impl TransactionEngine<MemEngine> for MemEngine {
+impl TxEngine<MemEngine> for MemEngine {
     fn trans_begin(&mut self) {}
     fn trans_commit(&mut self) -> Result<(), Error> {
         Ok(())

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -50,8 +50,8 @@ pub trait StatusEngine: Base {
     }
 }
 
-/// TransactionEngine offer a transaction to operate key-values and instances atomically
-pub trait TransactionEngine<T>: StatusEngine + InstanceEngine<T> {
+/// TxEngine offer a transactional operation on a storage.
+pub trait TxEngine<T>: StatusEngine + InstanceEngine<T> {
     /// start a transaction
     fn trans_begin(&mut self);
     /// commit a transaction

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -1,5 +1,6 @@
 use crate::qpaxos::{Instance, InstanceID};
 use crate::replica::ReplicaID;
+use num;
 
 // required by encode/decode
 use prost::Message;
@@ -7,16 +8,45 @@ use prost::Message;
 use super::Error;
 use super::InstanceIter;
 
+pub struct BaseIter<'a> {
+    pub cursor: Vec<u8>,
+    pub include: bool,
+    pub engine: &'a dyn Base,
+}
+
+impl<'a> Iterator for BaseIter<'a> {
+    type Item = (Vec<u8>, Vec<u8>);
+
+    // TODO add unittest.
+    fn next(&mut self) -> Option<Self::Item> {
+        let r = self.engine.next_kv(&self.cursor, self.include);
+        self.include = false;
+        match r {
+            Some(kv) => {
+                self.cursor = kv.0.clone();
+                Some(kv)
+            }
+            None => None,
+        }
+    }
+}
+
 /// Base offer basic key-value access
 pub trait Base {
     /// set a new key-value
     fn set_kv(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
     /// get an existing value with key
     fn get_kv(&self, key: &Vec<u8>) -> Result<Vec<u8>, Error>;
+
+    /// next_kv returns a key-value pair greater than the given one(include=false),
+    /// or greater or equal the given one(include=true)
+    fn next_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
+
+    fn get_iter(&self, key: Vec<u8>, include: bool) -> BaseIter;
 }
 
 /// InstanceEngine offer functions to operate snapshot instances
-pub trait InstanceEngine<T>: Base {
+pub trait InstanceEngine: StatusEngine {
     /// set a new instance
     fn set_instance(&mut self, iid: InstanceID, inst: Instance) -> Result<(), Error>;
     /// update an existing instance with instance id
@@ -24,22 +54,45 @@ pub trait InstanceEngine<T>: Base {
     /// get an instance with instance id
     fn get_instance(&self, iid: &InstanceID) -> Result<Instance, Error>;
     /// get an iterator to scan all instances with a leader replica id
-    fn get_instance_iter(&self, rid: ReplicaID) -> Result<InstanceIter<T>, Error>;
+    fn get_instance_iter(&self, rid: ReplicaID) -> Result<InstanceIter, Error>;
 }
 
 /// StatusEngine offer functions to operate snapshot status
-pub trait StatusEngine: Base {
+pub trait StatusEngine: TxEngine + Base {
+    type RID: num::Integer + std::fmt::LowerHex;
+    type Item: Message + std::default::Default;
+
     /// get current maximum instance id with a leader replica
-    fn get_max_instance_id(&self, rid: ReplicaID) -> Result<InstanceID, Error>;
+    fn get_max_instance_id(&self, rid: Self::RID) -> Result<Self::Item, Error> {
+        let key = self.max_instance_id_key(rid);
+        let val_bytes: Vec<u8> = self.get_kv(&key)?;
+
+        match Self::Item::decode(val_bytes.as_slice()) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(Error::DBError {
+                msg: "parse instance id error".to_string(),
+            }),
+        }
+    }
 
     /// get executed maximum continuous instance id with a leader replica
-    fn get_max_exec_instance_id(&self, rid: ReplicaID) -> Result<InstanceID, Error>;
+    fn get_max_exec_instance_id(&self, rid: Self::RID) -> Result<Self::Item, Error> {
+        let key = self.max_exec_instance_id_key(rid);
+        let val_bytes: Vec<u8> = self.get_kv(&key)?;
 
-    fn max_instance_id_key(&self, rid: ReplicaID) -> Vec<u8> {
+        match Self::Item::decode(val_bytes.as_slice()) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(Error::DBError {
+                msg: "parse instance id error".to_string(),
+            }),
+        }
+    }
+
+    fn max_instance_id_key(&self, rid: Self::RID) -> Vec<u8> {
         format!("/status/max_instance_id/{:x}", rid).into_bytes()
     }
 
-    fn max_exec_instance_id_key(&self, rid: ReplicaID) -> Vec<u8> {
+    fn max_exec_instance_id_key(&self, rid: Self::RID) -> Vec<u8> {
         format!("/status/max_exec_instance_id/{:x}", rid).into_bytes()
     }
 
@@ -51,7 +104,7 @@ pub trait StatusEngine: Base {
 }
 
 /// TxEngine offer a transactional operation on a storage.
-pub trait TxEngine<T>: StatusEngine + InstanceEngine<T> {
+pub trait TxEngine {
     /// start a transaction
     fn trans_begin(&mut self);
     /// commit a transaction

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -7,8 +7,8 @@ use prost::Message;
 use super::Error;
 use super::InstanceIter;
 
-/// KVEngine offer functions to operate snapshot key-values
-pub trait KVEngine {
+/// Base offer basic key-value access
+pub trait Base {
     /// set a new key-value
     fn set_kv(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
     /// get an existing value with key
@@ -16,7 +16,7 @@ pub trait KVEngine {
 }
 
 /// InstanceEngine offer functions to operate snapshot instances
-pub trait InstanceEngine<T>: KVEngine {
+pub trait InstanceEngine<T>: Base {
     /// set a new instance
     fn set_instance(&mut self, iid: InstanceID, inst: Instance) -> Result<(), Error>;
     /// update an existing instance with instance id
@@ -28,7 +28,7 @@ pub trait InstanceEngine<T>: KVEngine {
 }
 
 /// StatusEngine offer functions to operate snapshot status
-pub trait StatusEngine: KVEngine {
+pub trait StatusEngine: Base {
     /// get current maximum instance id with a leader replica
     fn get_max_instance_id(&self, rid: ReplicaID) -> Result<InstanceID, Error>;
 


### PR DESCRIPTION
# Description           <!-- summary, motivation and context -->

### refactor: storage engine traits
After adjust, the storage engine traits are:

-   trait Base: basice kv access.

-   trait TxEngine: transactional API, begin, commit etc.

-   trait StatusEngine: it is based on Base and TxEngine.

-   trait InstanceEngine: it is based on all these three, because updating
    instance requires the status to be updated together.

Removed unnecessary generics:

-   `Replica<E> -> Replica`: `Replica does not need to be abstract. Only the
    engine need to be abstract.

-   `InstanceIter<MemEngine> -> InstanceIter`: it does not need to know
    the underlying engine type, it only needs to know the trait the
    engine provides.

-   Moves `next_kv` to trait `Base`. Because scaning is a very basic
    operation for a **basic** kv-storage.
    Also a BaseIter is introduced for impl of iteration on trait Base.

-   `InstanceEngine<MemEngine> --> InstanceEngine`: it does not need to
    know what the engine it is to work perfectly.

-   Makes `get_max_instance_id` and `get_max_exec_instance_id` trait
    methods, instead of type methods.
    Because there is no differences for all types of storage.

add todo of testing instanceIter

## Type of change       <!-- delete irrelevant options. -->

- **Breaking change**   <!-- fix or feature that would cause existing functionality to not work as expected -->
- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
