### PR TITLE
Better trait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 
-cache: cargo
+# cache: cargo
 
 rust:
   - stable

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -53,7 +53,7 @@ pub struct Replica {
     pub latest_cp: InstanceID, // record the instance id in the lastest communication
 
     // storage
-    pub storage: Box<dyn InstanceEngine<RID = ReplicaID, Item = InstanceID>>,
+    pub storage: Box<dyn InstanceEngine<ColumnId = ReplicaID, ObjId = InstanceID, Obj = Instance>>,
 
     // to recover uncommitted instance
     pub problem_inst_ids: Vec<(InstanceID, SystemTime)>,

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -1,6 +1,7 @@
 use crate::qpaxos::{Instance, InstanceID};
 use crate::replica::ReplicaID;
-use num;
+use crate::tokey::ToKey;
+use std::fmt::LowerHex;
 
 // required by encode/decode
 use prost::Message;
@@ -35,6 +36,7 @@ impl<'a> Iterator for BaseIter<'a> {
 pub trait Base {
     /// set a new key-value
     fn set_kv(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
+
     /// get an existing value with key
     fn get_kv(&self, key: &Vec<u8>) -> Result<Vec<u8>, Error>;
 
@@ -54,46 +56,19 @@ pub trait InstanceEngine: StatusEngine {
     /// get an instance with instance id
     fn get_instance(&self, iid: &InstanceID) -> Result<Instance, Error>;
     /// get an iterator to scan all instances with a leader replica id
-    fn get_instance_iter(&self, rid: ReplicaID) -> Result<InstanceIter, Error>;
+    fn get_instance_iter(&self, rid: ReplicaID) -> InstanceIter;
 }
 
 /// StatusEngine offer functions to operate snapshot status
-pub trait StatusEngine: TxEngine + Base {
-    type RID: num::Integer + std::fmt::LowerHex;
-    type Item: Message + std::default::Default;
-
+pub trait StatusEngine: TxEngine + ColumnedEngine {
     /// get current maximum instance id with a leader replica
-    fn get_max_instance_id(&self, rid: Self::RID) -> Result<Self::Item, Error> {
-        let key = self.max_instance_id_key(rid);
-        let val_bytes: Vec<u8> = self.get_kv(&key)?;
-
-        match Self::Item::decode(val_bytes.as_slice()) {
-            Ok(v) => Ok(v),
-            Err(_) => Err(Error::DBError {
-                msg: "parse instance id error".to_string(),
-            }),
-        }
+    fn get_max_instance_id(&self, col_id: Self::ColumnId) -> Result<Self::ObjId, Error> {
+        self.get_ref("max", rid)
     }
 
     /// get executed maximum continuous instance id with a leader replica
-    fn get_max_exec_instance_id(&self, rid: Self::RID) -> Result<Self::Item, Error> {
-        let key = self.max_exec_instance_id_key(rid);
-        let val_bytes: Vec<u8> = self.get_kv(&key)?;
-
-        match Self::Item::decode(val_bytes.as_slice()) {
-            Ok(v) => Ok(v),
-            Err(_) => Err(Error::DBError {
-                msg: "parse instance id error".to_string(),
-            }),
-        }
-    }
-
-    fn max_instance_id_key(&self, rid: Self::RID) -> Vec<u8> {
-        format!("/status/max_instance_id/{:016x}", rid).into_bytes()
-    }
-
-    fn max_exec_instance_id_key(&self, rid: Self::RID) -> Vec<u8> {
-        format!("/status/max_exec_instance_id/{:016x}", rid).into_bytes()
+    fn get_max_exec_instance_id(&self, rid: Self::ColumnId) -> Result<Self::ObjId, Error> {
+        self.get_ref("exec", rid)
     }
 
     fn set_instance_id(&mut self, key: Vec<u8>, iid: InstanceID) -> Result<(), Error> {
@@ -113,4 +88,92 @@ pub trait TxEngine {
     fn trans_rollback(&mut self) -> Result<(), Error>;
     /// get a key to set exclusively, must be called in an transaction
     fn get_kv_for_update(&self, key: &Vec<u8>) -> Result<Vec<u8>, Error>;
+}
+
+/// ObjectEngine wraps bytes based storage engine into an object based engine.
+/// Structured object can be stored and retreived with similar APIs.
+/// An object is serialized into bytes with protobuf engine prost.
+///
+/// TODO example
+pub trait ObjectEngine: Base {
+    /// ObjId defines the type of object id.
+    /// It must be able to convert to a key in order to store an object.
+    /// Alsot it needs to be serialized as Message in order to be stored as an object too.
+    type ObjId: ToKey + Message + std::default::Default;
+
+    /// Obj defines the type of an object.
+    type Obj: Message + std::default::Default;
+
+    fn set_obj(&mut self, item_id: Self::ObjId, item: &Self::Obj) -> Result<(), Error> {
+        let key = item_id.to_key();
+        let value = self.encode_obj(item)?;
+
+        self.set_kv(key, value)
+    }
+
+    fn get_obj(&self, item_id: &Self::ObjId) -> Result<Self::Obj, Error> {
+        let key = item_id.to_key();
+        let val_bytes = self.get_kv(&key)?;
+
+        let itm = self.decode_obj(&val_bytes)?;
+        Ok(itm)
+    }
+
+    fn encode_obj(&self, itm: &Self::Obj) -> Result<Vec<u8>, Error> {
+        let mut value = vec![];
+        itm.encode(&mut value).unwrap();
+        Ok(value)
+    }
+
+    fn decode_obj(&self, bs: &Vec<u8>) -> Result<Self::Obj, Error> {
+        match Self::Obj::decode(bs.as_slice()) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(Error::DBError {
+                msg: "parse instance id error".to_string(),
+            }),
+        }
+    }
+}
+
+/// ColumnedEngine organizes object in columns.
+/// Because the underlying storage is a simple object store,
+/// it introduces ColumnId to classify objects.
+/// And also it provides APIs to track objects in different columns.
+///
+/// set_ref(type, col_id, obj_id) to store a column reference of `type` to be `obj_id`.
+///
+/// E.g.: `set_ref("max", 1, (1, 2))` to set the "max" object in column 1 to be object with object-id
+/// (1, 2)
+///
+/// A User should implement make_ref_key() to make reference keys.
+pub trait ColumnedEngine: ObjectEngine {
+    type ColumnId;
+
+    fn make_ref_key(&self, typ: &str, col_id: Self::ColumnId) -> Vec<u8>;
+
+    fn set_ref(
+        &mut self,
+        typ: &str,
+        col_id: Self::ColumnId,
+        item_id: Self::ObjId,
+    ) -> Result<(), Error> {
+        let key = self.make_ref_key(typ, col_id);
+
+        let mut value = vec![];
+        item_id.encode(&mut value).unwrap();
+
+        self.set_kv(key, value)
+    }
+
+    fn get_ref(&self, typ: &str, col_id: Self::ColumnId) -> Result<Self::ObjId, Error> {
+        let key = self.make_ref_key(typ, col_id);
+        let val_bytes = self.get_kv(&key)?;
+
+        match Self::ObjId::decode(val_bytes.as_slice()) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(Error::DBError {
+                msg: "parse instance id error".to_string(),
+            }),
+        }
+    }
 }

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -63,12 +63,12 @@ pub trait InstanceEngine: StatusEngine {
 pub trait StatusEngine: TxEngine + ColumnedEngine {
     /// get current maximum instance id with a leader replica
     fn get_max_instance_id(&self, col_id: Self::ColumnId) -> Result<Self::ObjId, Error> {
-        self.get_ref("max", rid)
+        self.get_ref("max", col_id)
     }
 
     /// get executed maximum continuous instance id with a leader replica
-    fn get_max_exec_instance_id(&self, rid: Self::ColumnId) -> Result<Self::ObjId, Error> {
-        self.get_ref("exec", rid)
+    fn get_max_exec_instance_id(&self, col_id: Self::ColumnId) -> Result<Self::ObjId, Error> {
+        self.get_ref("exec", col_id)
     }
 
     fn set_instance_id(&mut self, key: Vec<u8>, iid: InstanceID) -> Result<(), Error> {


### PR DESCRIPTION
### refactor: engines: seperate storage logic and bz logic
Move unrelated functions into separate traits.
And in order to maximize sharing, I tried to move as much functionality as
possible from implementation into traits.

Storage engine traits layers:
`Base -> ObjectEngine -> ColumnedEngine -> StatusEngine -> InstanceEngine`

-   At the bottom level, it is `trait Base` which is a bytes oriented engine
    and `trait TxEngine` which provides basic tx operation.

-   Upon `Base` it is `trait ObjectEngine`, which provides APIs to read/write rust
    struct, the type of struct is specified by trait implementation.

    In our impl, `Object` is set to `Instance`

-   Upon `ObjectEngine` it is `ColumnedEngine`.
    It organizes object in columns and provides "reference" to track
    objects in columns.

    E.g. `get_ref("max", col_id)` to get max object id in column
    `col_id`, which is previously stored with
    `set_ref("max", col_id, obj_id)`.

    In our impl, `ColumnId` is `ReplicaID` and we use `reference`
    as a replacement of `get_max_instance_id` or
    `get_max_exec_instance_id`.

-   On the top it is `StatusEngine` based on `ColumnedEngine` and
    `TxEngine`.


### get_instance_iter does not return any error

## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
