### PR TITLE
Rm status engine

### DIFF
--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -80,7 +80,7 @@ impl Replica {
         let mut new_inst = inst.clone();
         new_inst.executed = true;
         self.storage
-            .update_instance(inst.instance_id.unwrap(), new_inst)?;
+            .update_instance(inst.instance_id.unwrap(), &new_inst)?;
 
         Ok(rst)
     }

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -5,7 +5,7 @@ use super::super::conf::ClusterInfo;
 
 use super::super::qpaxos::*;
 
-use super::super::snapshot::{InstanceEngine, StatusEngine, TxEngine};
+use super::super::snapshot::{InstanceEngine, TxEngine};
 
 #[cfg(test)]
 #[path = "./tests/replica_tests.rs"]

--- a/components/epaxos/src/snapshot/iters.rs
+++ b/components/epaxos/src/snapshot/iters.rs
@@ -60,9 +60,9 @@ mod tests {
                 let deps = vec![InstanceID::from((rid + 1, idx + 1))];
                 let inst = Instance::of(&cmds[..], &ballot, &deps[..]);
 
-                let _ = engine.set_instance(iid, inst.clone()).unwrap();
+                let _ = engine.set_instance(iid, &inst).unwrap();
 
-                let act = engine.get_instance(&iid).unwrap();
+                let act = engine.get_obj(iid).unwrap();
                 assert_eq!(act.cmds, cmds);
 
                 ints.push(inst);

--- a/components/epaxos/src/snapshot/mod.rs
+++ b/components/epaxos/src/snapshot/mod.rs
@@ -15,3 +15,6 @@ pub use mem_engine::*;
 
 mod iters;
 pub use iters::*;
+
+#[cfg(test)]
+mod test_engine;

--- a/components/epaxos/src/snapshot/test_engine.rs
+++ b/components/epaxos/src/snapshot/test_engine.rs
@@ -1,7 +1,7 @@
-use crate::qpaxos::*;
+use super::errors::*;
 use super::mem_engine::*;
 use super::traits::*;
-use super::errors::*;
+use crate::qpaxos::*;
 
 #[test]
 fn test_engine_mem_set_instance() {
@@ -40,14 +40,13 @@ fn test_engine_mem_set_instance() {
 }
 
 fn new_foo_inst(leader_id: i64) -> Instance {
-
     let iid1 = InstanceID::from((1, 10));
     let iid2 = InstanceID::from((2, 20));
     let iid3 = InstanceID::from((3, 30));
     let initial_deps = vec![iid1, iid2, iid3];
 
     let cmd1 = ("NoOp", "k1", "v1").into();
-    let cmd2 = ("Get",  "k2", "v2").into();
+    let cmd2 = ("Get", "k2", "v2").into();
     let cmds = vec![cmd1, cmd2];
     let ballot = (0, 0, leader_id).into();
     let ballot2 = (1, 2, leader_id).into();

--- a/components/epaxos/src/snapshot/test_engine.rs
+++ b/components/epaxos/src/snapshot/test_engine.rs
@@ -1,0 +1,63 @@
+use crate::qpaxos::*;
+use super::mem_engine::*;
+use super::traits::*;
+use super::errors::*;
+
+#[test]
+fn test_engine_mem_set_instance() {
+    let leader_id = 2;
+    let mut eng = MemEngine::new().unwrap();
+    let mut inst = new_foo_inst(leader_id);
+    let iid = inst.instance_id.unwrap();
+    eng.set_instance(iid, &inst).unwrap();
+
+    assert_eq!(iid, eng.get_ref("max", leader_id).unwrap());
+    assert_eq!(Err(Error::NotFound), eng.get_ref("exec", leader_id));
+
+    // exec-ref is updated if executed
+
+    inst.executed = true;
+    eng.set_instance(iid, &inst).unwrap();
+    assert_eq!(iid, eng.get_ref("exec", leader_id).unwrap());
+
+    // exec-ref is not updated, max is updated
+
+    inst.executed = false;
+    inst.instance_id = Some((leader_id, 10).into());
+    let iid2 = inst.instance_id.unwrap();
+    eng.set_instance(iid2, &inst).unwrap();
+    assert_eq!(iid2, eng.get_ref("max", leader_id).unwrap());
+    assert_eq!(iid, eng.get_ref("exec", leader_id).unwrap());
+
+    // exec-ref is not updated, max is not updated
+
+    inst.executed = false;
+    inst.instance_id = Some((leader_id, 0).into());
+    let iid3 = inst.instance_id.unwrap();
+    eng.set_instance(iid3, &inst).unwrap();
+    assert_eq!(iid2, eng.get_ref("max", leader_id).unwrap());
+    assert_eq!(iid, eng.get_ref("exec", leader_id).unwrap());
+}
+
+fn new_foo_inst(leader_id: i64) -> Instance {
+
+    let iid1 = InstanceID::from((1, 10));
+    let iid2 = InstanceID::from((2, 20));
+    let iid3 = InstanceID::from((3, 30));
+    let initial_deps = vec![iid1, iid2, iid3];
+
+    let cmd1 = ("NoOp", "k1", "v1").into();
+    let cmd2 = ("Get",  "k2", "v2").into();
+    let cmds = vec![cmd1, cmd2];
+    let ballot = (0, 0, leader_id).into();
+    let ballot2 = (1, 2, leader_id).into();
+
+    let mut inst = Instance::of(&cmds[..], &ballot, &initial_deps[..]);
+    // TODO move these to Instance::new_instance
+    inst.instance_id = Some((leader_id, 1).into());
+    inst.deps = [iid2].to_vec();
+    inst.final_deps = [iid3].to_vec();
+    inst.last_ballot = Some(ballot2);
+
+    inst
+}

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -49,7 +49,6 @@ pub trait Base {
 
 /// InstanceEngine offer functions to operate snapshot instances
 pub trait InstanceEngine: TxEngine + ColumnedEngine {
-
     /// set a new instance
     fn set_instance(&mut self, iid: InstanceID, inst: &Instance) -> Result<(), Error>;
 
@@ -181,20 +180,19 @@ pub trait ColumnedEngine: ObjectEngine {
         col_id: Self::ColumnId,
         objid: Self::ObjId,
         default: Self::ObjId,
-        cond: P
-    ) -> Result<(), Error> where
-        Self: Sized, 
-        P: Fn(Self::ObjId) -> bool, 
+        cond: P,
+    ) -> Result<(), Error>
+    where
+        Self: Sized,
+        P: Fn(Self::ObjId) -> bool,
     {
         let r0 = self.get_ref(typ, col_id);
         let r0 = match r0 {
             Ok(v) => v,
             Err(e) => match e {
                 Error::NotFound => default,
-                _ => {
-                    return Err(e)
-                }
-            }
+                _ => return Err(e),
+            },
         };
 
         if cond(r0) {


### PR DESCRIPTION
### feat: remove StatusEngine
-   Add contrains that ColumnId : Copy

-   Add `set_ref_if`: update ref only if provided condition satisfied.

-   Simplify `set_instance` with conditional setter: `set_ref_if`.

-   Add test of `set_instance`.

-   Remove StatusEngine. Use method from ColumnedEngine instead.

-   Follow the convention that pass parameter xxID as value, xx as
    reference if it is not consumed.

-   Rename some local vars.

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Test changes**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
