### PR TITLE
refactor: get_instance() returns Result<Option<>, Err>

### DIFF
--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -14,6 +14,7 @@ mod t;
 mod test_command;
 
 pub type InstanceIdx = i64;
+pub type ReplicaID = i64;
 
 // prost issue, it renames InstanceID to InstanceId
 pub type InstanceID = InstanceId;
@@ -57,10 +58,6 @@ impl ToKey for InstanceID {
 }
 
 impl InstanceID {
-    pub fn of(replica_id: i64, idx: i64) -> InstanceID {
-        InstanceID { replica_id, idx }
-    }
-
     pub fn from_key(s: &str) -> Option<InstanceID> {
         let items: Vec<&str> = s.split("/").collect();
         if items[1] == "instance" && items.len() == 4 {

--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -43,7 +43,7 @@ impl Replica {
                     .find(|x| x.replica_id == dep_inst_id.replica_id)
                 {
                     if dep_inst_id.idx > iid.idx {
-                        rst.push(InstanceID::of(iid.replica_id, iid.idx + 1));
+                        rst.push(InstanceID::from((iid.replica_id, iid.idx + 1)));
                     }
                 }
             }

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -11,8 +11,6 @@ use super::super::snapshot::{InstanceEngine, TxEngine};
 #[path = "./tests/replica_tests.rs"]
 mod tests;
 
-pub type ReplicaID = i64;
-
 /// information of communication peer
 pub struct ReplicaPeer {
     pub replica_id: ReplicaID,

--- a/components/epaxos/src/replica/tests/exec_tests.rs
+++ b/components/epaxos/src/replica/tests/exec_tests.rs
@@ -33,7 +33,7 @@ fn test_find_missing_instances() {
                 final_deps: vec![(1, 1).into()],
                 ..Default::default()
             }],
-            vec![InstanceID::of(1, 1)],
+            vec![InstanceID::from((1, 1))],
         ),
         // R1               R2              R3
         // |                |               |
@@ -56,7 +56,7 @@ fn test_find_missing_instances() {
                     ..Default::default()
                 },
             ],
-            vec![InstanceID::of(1, 1), (2, 1).into(), (3, 10).into()],
+            vec![InstanceID::from((1, 1)), (2, 1).into(), (3, 10).into()],
         ),
     ];
 
@@ -84,8 +84,8 @@ fn test_find_missing_instances() {
                 final_deps: vec![(1, 1).into(), (2, 6).into(), (3, 6).into()],
                 ..Default::default()
             }],
-            vec![InstanceID::of(1, 1), (2, 5).into(), (3, 5).into()],
-            vec![InstanceID::of(2, 6), (3, 6).into()],
+            vec![InstanceID::from((1, 1)), (2, 5).into(), (3, 5).into()],
+            vec![InstanceID::from((2, 6)), (3, 6).into()],
         ),
         // R1               R2              R3
         // |                |               |
@@ -110,8 +110,8 @@ fn test_find_missing_instances() {
                     ..Default::default()
                 },
             ],
-            vec![InstanceID::of(1, 1), (2, 1).into(), (3, 1).into()],
-            vec![InstanceID::of(3, 2)],
+            vec![InstanceID::from((1, 1)), (2, 1).into(), (3, 1).into()],
+            vec![InstanceID::from((3, 2))],
         ),
     ];
 
@@ -213,7 +213,7 @@ fn test_execute_instances() {
             ..Default::default()
         },
         Instance {
-            instance_id: Some(InstanceID::of(2, 1)),
+            instance_id: Some(InstanceID::from((2, 1))),
             cmds: vec![Command::of(OpCode::NoOp, &[], &[])],
             final_deps: vec![(1, 1).into(), (2, 0).into(), (3, 0).into()],
             ..Default::default()
@@ -227,7 +227,7 @@ fn test_execute_instances() {
     ];
 
     match rp.execute_instances(&min_insts) {
-        Ok(iids) => assert_eq!(vec![InstanceID::of(1, 1)], iids),
+        Ok(iids) => assert_eq!(vec![InstanceID::from((1, 1))], iids),
         Err(_) => assert!(false),
     };
 
@@ -240,7 +240,7 @@ fn test_execute_instances() {
             ..Default::default()
         },
         Instance {
-            instance_id: Some(InstanceID::of(2, 1)),
+            instance_id: Some(InstanceID::from((2, 1))),
             cmds: vec![Command::of(OpCode::NoOp, &[], &[])],
             final_deps: vec![(1, 1).into(), (2, 0).into(), (3, 0).into()],
             ..Default::default()
@@ -255,7 +255,7 @@ fn test_execute_instances() {
 
     match rp.execute_instances(&min_insts) {
         Ok(iids) => assert_eq!(
-            vec![InstanceID::of(1, 1), (2, 1).into(), (3, 1).into()],
+            vec![InstanceID::from((1, 1)), (2, 1).into(), (3, 1).into()],
             iids
         ),
         Err(_) => assert!(false),
@@ -272,7 +272,7 @@ fn test_execute_instances() {
             ..Default::default()
         },
         Instance {
-            instance_id: Some(InstanceID::of(2, 1)),
+            instance_id: Some(InstanceID::from((2, 1))),
             cmds: vec![Command::of(OpCode::NoOp, &[], &[])],
             final_deps: vec![(1, 1).into(), (2, 0).into(), (3, 0).into()],
             ..Default::default()
@@ -286,7 +286,7 @@ fn test_execute_instances() {
     ];
 
     match rp.execute_instances(&min_insts) {
-        Ok(iids) => assert_eq!(vec![InstanceID::of(1, 1), (2, 1).into()], iids),
+        Ok(iids) => assert_eq!(vec![InstanceID::from((1, 1)), (2, 1).into()], iids),
         Err(_) => assert!(false),
     };
 }

--- a/components/epaxos/src/snapshot/iters.rs
+++ b/components/epaxos/src/snapshot/iters.rs
@@ -62,7 +62,7 @@ mod tests {
 
                 let _ = engine.set_instance(iid, &inst).unwrap();
 
-                let act = engine.get_obj(iid).unwrap();
+                let act = engine.get_obj(iid).unwrap().unwrap();
                 assert_eq!(act.cmds, cmds);
 
                 ints.push(inst);

--- a/components/epaxos/src/snapshot/mem_engine/memdb.rs
+++ b/components/epaxos/src/snapshot/mem_engine/memdb.rs
@@ -5,9 +5,7 @@ use super::MemEngine;
 use prost::Message;
 
 use super::super::*;
-use crate::qpaxos::{BallotNum, Instance, InstanceID};
-use crate::qpaxos::{Command, OpCode};
-use crate::replica::ReplicaID;
+use crate::qpaxos::*;
 
 use super::super::super::tokey::ToKey;
 
@@ -89,14 +87,13 @@ impl InstanceEngine for MemEngine {
         Ok(())
     }
     /// get an instance with instance id
-    fn get_instance(&self, iid: InstanceID) -> Result<Self::Obj, Error> {
+    fn get_instance(&self, iid: InstanceID) -> Result<Option<Instance>, Error> {
         self.get_obj(iid)
     }
 
     fn get_instance_iter(&self, rid: ReplicaID) -> InstanceIter {
-        let iid = InstanceID::from((rid, 0));
         InstanceIter {
-            curr_inst_id: iid,
+            curr_inst_id: (rid, 0).into(),
             include: true,
             engine: self,
         }
@@ -163,7 +160,7 @@ mod tests {
                 let act = engine.get_ref("max", rid).unwrap();
                 assert_eq!(act, iid);
 
-                let act = engine.get_obj(iid).unwrap();
+                let act = engine.get_obj(iid).unwrap().unwrap();
 
                 assert_eq!(act.cmds, cmds);
                 assert_eq!(act.ballot, Some(ballot));

--- a/components/epaxos/src/snapshot/test_engine.rs
+++ b/components/epaxos/src/snapshot/test_engine.rs
@@ -5,8 +5,14 @@ use crate::qpaxos::*;
 
 #[test]
 fn test_engine_mem_set_instance() {
-    let leader_id = 2;
     let mut eng = MemEngine::new().unwrap();
+    test_set_instance(&mut eng);
+}
+
+fn test_set_instance(
+    eng: &mut InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
+) {
+    let leader_id = 2;
     let mut inst = new_foo_inst(leader_id);
     let iid = inst.instance_id.unwrap();
     eng.set_instance(iid, &inst).unwrap();
@@ -37,6 +43,27 @@ fn test_engine_mem_set_instance() {
     eng.set_instance(iid3, &inst).unwrap();
     assert_eq!(iid2, eng.get_ref("max", leader_id).unwrap());
     assert_eq!(iid, eng.get_ref("exec", leader_id).unwrap());
+}
+
+#[test]
+fn test_engine_mem_get_instance() {
+    let mut eng = MemEngine::new().unwrap();
+    test_get_instance(&mut eng);
+}
+
+fn test_get_instance(
+    eng: &mut InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
+) {
+    let leader_id = 2;
+    let mut inst = new_foo_inst(leader_id);
+    let iid = inst.instance_id.unwrap();
+
+    let noninst = eng.get_instance(iid).unwrap();
+    assert_eq!(None, noninst);
+
+    eng.set_instance(iid, &inst).unwrap();
+    let got = eng.get_instance(iid).unwrap();
+    assert_eq!(Some(inst), got);
 }
 
 fn new_foo_inst(leader_id: i64) -> Instance {


### PR DESCRIPTION
- In order to distinguish not-found from other unhandlable error, result
  is an Option<Instance> instead of Instance.

  Add test of get_instance().

- Move replicaID into mod qpaxos, because it is a core concept for
  replication.

- refactor: remove InstanceID::of, use ::from instead

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
