### PR TITLE
feat: add next_instance_id()

### DIFF
--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -80,7 +80,7 @@ impl Replica {
         let mut new_inst = inst.clone();
         new_inst.executed = true;
         self.storage
-            .update_instance(inst.instance_id.unwrap(), &new_inst)?;
+            .set_instance(inst.instance_id.unwrap(), &new_inst)?;
 
         Ok(rst)
     }

--- a/components/epaxos/src/snapshot/test_engine.rs
+++ b/components/epaxos/src/snapshot/test_engine.rs
@@ -10,7 +10,7 @@ fn test_engine_mem_set_instance() {
 }
 
 fn test_set_instance(
-    eng: &mut InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
+    eng: &mut dyn InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
 ) {
     let leader_id = 2;
     let mut inst = new_foo_inst(leader_id);
@@ -52,7 +52,7 @@ fn test_engine_mem_get_instance() {
 }
 
 fn test_get_instance(
-    eng: &mut InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
+    eng: &mut dyn InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
 ) {
     let leader_id = 2;
     let mut inst = new_foo_inst(leader_id);
@@ -64,6 +64,30 @@ fn test_get_instance(
     eng.set_instance(iid, &inst).unwrap();
     let got = eng.get_instance(iid).unwrap();
     assert_eq!(Some(inst), got);
+}
+
+#[test]
+fn test_engine_mem_next_instance_id() {
+    let mut eng = MemEngine::new().unwrap();
+    test_next_instance_id(&mut eng);
+}
+
+fn test_next_instance_id(
+    eng: &mut dyn InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
+) {
+    let leader_id = 2;
+    let max = (leader_id, 3).into();
+
+    let init = eng.next_instance_id(leader_id).unwrap();
+    assert_eq!(InstanceID::from((leader_id, 0)), init);
+
+    let got = eng.next_instance_id(leader_id).unwrap();
+    assert_eq!(InstanceID::from((leader_id, 1)), got);
+
+    eng.set_ref("max", leader_id, max).unwrap();
+
+    let got = eng.next_instance_id(leader_id).unwrap();
+    assert_eq!(InstanceID::from((leader_id, 4)), got);
 }
 
 fn new_foo_inst(leader_id: i64) -> Instance {

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -48,13 +48,11 @@ pub trait Base {
 
 /// InstanceEngine offer functions to operate snapshot instances
 pub trait InstanceEngine: TxEngine + ColumnedEngine {
-    /// set a new instance
-    fn set_instance(&mut self, iid: InstanceID, inst: &Instance) -> Result<(), Error>;
+    /// Find next available instance id and increase max-instance-id ref.
+    fn next_instance_id(&mut self, rid: ReplicaID) -> Result<InstanceID, Error>;
 
-    /// update an existing instance with instance id
-    fn update_instance(&mut self, iid: InstanceID, inst: &Instance) -> Result<(), Error> {
-        self.set_instance(iid, inst)
-    }
+    /// set an instance
+    fn set_instance(&mut self, iid: InstanceID, inst: &Instance) -> Result<(), Error>;
 
     /// get an instance with instance id
     fn get_instance(&self, iid: InstanceID) -> Result<Option<Instance>, Error>;


### PR DESCRIPTION
- next_instance_id() incr "max" ref and return the next available instance id.

- Remove update_instance(). Use set_instance() instead.


## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
