### PR TITLE
Set instance without instance id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 
-# cache: cargo
+cache: cargo
 
 rust:
   - stable

--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -79,8 +79,7 @@ impl Replica {
 
         let mut new_inst = inst.clone();
         new_inst.executed = true;
-        self.storage
-            .set_instance(inst.instance_id.unwrap(), &new_inst)?;
+        self.storage.set_instance(&new_inst)?;
 
         Ok(rst)
     }

--- a/components/epaxos/src/snapshot/iters.rs
+++ b/components/epaxos/src/snapshot/iters.rs
@@ -58,9 +58,10 @@ mod tests {
 
                 let ballot = (rid as i32, idx as i32, 0).into();
                 let deps = vec![InstanceID::from((rid + 1, idx + 1))];
-                let inst = Instance::of(&cmds[..], &ballot, &deps[..]);
+                let mut inst = Instance::of(&cmds[..], &ballot, &deps[..]);
+                inst.instance_id = Some(iid);
 
-                let _ = engine.set_instance(iid, &inst).unwrap();
+                let _ = engine.set_instance(&inst).unwrap();
 
                 let act = engine.get_obj(iid).unwrap().unwrap();
                 assert_eq!(act.cmds, cmds);

--- a/components/epaxos/src/snapshot/test_engine.rs
+++ b/components/epaxos/src/snapshot/test_engine.rs
@@ -15,15 +15,14 @@ fn test_set_instance(
     let leader_id = 2;
     let mut inst = new_foo_inst(leader_id);
     let iid = inst.instance_id.unwrap();
-    eng.set_instance(iid, &inst).unwrap();
+    eng.set_instance(&inst).unwrap();
 
-    assert_eq!(iid, eng.get_ref("max", leader_id).unwrap());
     assert_eq!(Err(Error::NotFound), eng.get_ref("exec", leader_id));
 
     // exec-ref is updated if executed
 
     inst.executed = true;
-    eng.set_instance(iid, &inst).unwrap();
+    eng.set_instance(&inst).unwrap();
     assert_eq!(iid, eng.get_ref("exec", leader_id).unwrap());
 
     // exec-ref is not updated, max is updated
@@ -31,8 +30,7 @@ fn test_set_instance(
     inst.executed = false;
     inst.instance_id = Some((leader_id, 10).into());
     let iid2 = inst.instance_id.unwrap();
-    eng.set_instance(iid2, &inst).unwrap();
-    assert_eq!(iid2, eng.get_ref("max", leader_id).unwrap());
+    eng.set_instance(&inst).unwrap();
     assert_eq!(iid, eng.get_ref("exec", leader_id).unwrap());
 
     // exec-ref is not updated, max is not updated
@@ -40,8 +38,7 @@ fn test_set_instance(
     inst.executed = false;
     inst.instance_id = Some((leader_id, 0).into());
     let iid3 = inst.instance_id.unwrap();
-    eng.set_instance(iid3, &inst).unwrap();
-    assert_eq!(iid2, eng.get_ref("max", leader_id).unwrap());
+    eng.set_instance(&inst).unwrap();
     assert_eq!(iid, eng.get_ref("exec", leader_id).unwrap());
 }
 
@@ -61,7 +58,7 @@ fn test_get_instance(
     let noninst = eng.get_instance(iid).unwrap();
     assert_eq!(None, noninst);
 
-    eng.set_instance(iid, &inst).unwrap();
+    eng.set_instance(&inst).unwrap();
     let got = eng.get_instance(iid).unwrap();
     assert_eq!(Some(inst), got);
 }

--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -52,7 +52,7 @@ pub trait InstanceEngine: TxEngine + ColumnedEngine {
     fn next_instance_id(&mut self, rid: ReplicaID) -> Result<InstanceID, Error>;
 
     /// set an instance
-    fn set_instance(&mut self, iid: InstanceID, inst: &Instance) -> Result<(), Error>;
+    fn set_instance(&mut self, inst: &Instance) -> Result<(), Error>;
 
     /// get an instance with instance id
     fn get_instance(&self, iid: InstanceID) -> Result<Option<Instance>, Error>;


### PR DESCRIPTION
### feat: set_instance() do not need instance_id.

set_instance() should not update "max" ref. "max" ref should only be
updated by next_instance_id().

set_instance() do not need arg instance_id.

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Breaking change**   <!-- fix or feature that would cause existing functionality to not work as expected -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
