### PR TITLE
feat: Instance::conflict() to check if two instance contains conflicting commands

### DIFF
--- a/components/epaxos/src/qpaxos/t.rs
+++ b/components/epaxos/src/qpaxos/t.rs
@@ -18,7 +18,7 @@ fn new_foo_inst() -> Instance {
     let ballot = (0, 0, replica).into();
     let ballot2 = (1, 2, replica).into();
 
-    let mut inst = Instance::of(&cmds[..], &ballot, &initial_deps[..]);
+    let mut inst = Instance::of(&cmds[..], ballot, &initial_deps[..]);
     // TODO move these to Instance::new_instance
     inst.instance_id = Some(inst_id1);
     inst.deps = [inst_id2].to_vec();
@@ -56,7 +56,7 @@ fn test_instance_protobuf() {
     let cmds = vec![cmd1, cmd2];
     let ballot = (1, 2, 3).into();
 
-    let inst1 = Instance::of(&cmds[..], &ballot, &initial_deps[..]);
+    let inst1 = Instance::of(&cmds[..], ballot, &initial_deps[..]);
 
     test_enc_dec!(inst1, Instance);
 }

--- a/components/epaxos/src/qpaxos/test_instance.rs
+++ b/components/epaxos/src/qpaxos/test_instance.rs
@@ -1,0 +1,38 @@
+use crate::qpaxos::*;
+
+#[test]
+fn test_instance_conflict() {
+    let nx = Command::from(("NoOp", "x", "1"));
+    let gx = Command::from(("Get", "x", "1"));
+    let sx = Command::from(("Set", "x", "1"));
+
+    let ny = Command::from(("NoOp", "y", "1"));
+    let gy = Command::from(("Get", "y", "1"));
+    let sy = Command::from(("Set", "y", "1"));
+
+    let nxny = Instance::of(&[nx.clone(), ny.clone()], (0, 0, 0).into(), &[]);
+    let gxny = Instance::of(&[gx.clone(), ny.clone()], (0, 0, 0).into(), &[]);
+    let sxny = Instance::of(&[sx.clone(), ny.clone()], (0, 0, 0).into(), &[]);
+    let sxsy = Instance::of(&[sx.clone(), sy.clone()], (0, 0, 0).into(), &[]);
+    let gxsy = Instance::of(&[gx.clone(), sy.clone()], (0, 0, 0).into(), &[]);
+
+    assert!(!nxny.conflict(&nxny));
+    assert!(!nxny.conflict(&gxny));
+    assert!(!nxny.conflict(&sxny));
+    assert!(!nxny.conflict(&sxsy));
+    assert!(!nxny.conflict(&gxsy));
+
+    assert!(!gxny.conflict(&gxny));
+    assert!(gxny.conflict(&sxny));
+    assert!(gxny.conflict(&sxsy));
+    assert!(!gxny.conflict(&gxsy));
+
+    assert!(sxny.conflict(&sxny));
+    assert!(sxny.conflict(&sxsy));
+    assert!(sxny.conflict(&gxsy));
+
+    assert!(sxsy.conflict(&sxsy));
+    assert!(sxsy.conflict(&gxsy));
+
+    assert!(gxsy.conflict(&gxsy));
+}

--- a/components/epaxos/src/snapshot/iters.rs
+++ b/components/epaxos/src/snapshot/iters.rs
@@ -58,7 +58,7 @@ mod tests {
 
                 let ballot = (rid as i32, idx as i32, 0).into();
                 let deps = vec![InstanceID::from((rid + 1, idx + 1))];
-                let mut inst = Instance::of(&cmds[..], &ballot, &deps[..]);
+                let mut inst = Instance::of(&cmds[..], ballot, &deps[..]);
                 inst.instance_id = Some(iid);
 
                 let _ = engine.set_instance(&inst).unwrap();

--- a/components/epaxos/src/snapshot/mem_engine/memdb.rs
+++ b/components/epaxos/src/snapshot/mem_engine/memdb.rs
@@ -171,7 +171,7 @@ mod tests {
 
                 let deps = vec![InstanceID::from((rid + 1, idx + 1))];
 
-                let mut inst = Instance::of(&cmds[..], &ballot, &deps[..]);
+                let mut inst = Instance::of(&cmds[..], ballot, &deps[..]);
                 inst.instance_id = Some(iid);
 
                 engine.set_instance(&inst).unwrap();

--- a/components/epaxos/src/snapshot/test_engine.rs
+++ b/components/epaxos/src/snapshot/test_engine.rs
@@ -99,7 +99,7 @@ fn new_foo_inst(leader_id: i64) -> Instance {
     let ballot = (0, 0, leader_id).into();
     let ballot2 = (1, 2, leader_id).into();
 
-    let mut inst = Instance::of(&cmds[..], &ballot, &initial_deps[..]);
+    let mut inst = Instance::of(&cmds[..], ballot, &initial_deps[..]);
     // TODO move these to Instance::new_instance
     inst.instance_id = Some((leader_id, 1).into());
     inst.deps = [iid2].to_vec();


### PR DESCRIPTION
### feat: Instance::conflict() to check if two instance contains conflicting commands

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
