### PR TITLE
fix: InstanceIter

### DIFF
--- a/components/epaxos/src/snapshot/traits.rs
+++ b/components/epaxos/src/snapshot/traits.rs
@@ -58,7 +58,7 @@ pub trait InstanceEngine: TxEngine + ColumnedEngine {
     fn get_instance(&self, iid: InstanceID) -> Result<Option<Instance>, Error>;
 
     /// get an iterator to scan all instances with a leader replica id
-    fn get_instance_iter(&self, rid: Self::ColumnId) -> InstanceIter;
+    fn get_instance_iter(&self, iid: InstanceID, include: bool) -> InstanceIter;
 }
 
 /// TxEngine offer a transactional operation on a storage.


### PR DESCRIPTION
- InstanceIter should use InstanceEngine instead of Base.

- InstanceIter should use instanceID as cursor type, instead of ReplicaID.
  get_instance_iter() should accept a `include` arg.

- Add error handling to InstanceIter. Also complete tests.


## Type of change       <!-- delete irrelevant options. -->

- **Bug fix**           <!-- non-breaking change which fixes an issue -->
- **New feature**       <!-- non-breaking change which adds functionality -->
- **Breaking change**   <!-- fix or feature that would cause existing functionality to not work as expected -->
- **Test changes**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
