### PR TITLE
调整 snapshot traits 的测试结构

### DIFF
--- a/components/epaxos/src/snapshot/mem_engine/memdb.rs
+++ b/components/epaxos/src/snapshot/mem_engine/memdb.rs
@@ -246,4 +246,22 @@ mod tests {
 
         assert_eq!(v, engine.get_kv(&k).unwrap());
     }
+
+    #[test]
+    fn test_instance_engine() {
+        {
+            let mut engine = MemEngine::new().unwrap();
+            test_set_instance(&mut engine);
+        }
+
+        {
+            let mut engine = MemEngine::new().unwrap();
+            test_get_instance(&mut engine);
+        }
+
+        {
+            let mut engine = MemEngine::new().unwrap();
+            test_next_instance_id(&mut engine);
+        }
+    }
 }

--- a/components/epaxos/src/snapshot/mod.rs
+++ b/components/epaxos/src/snapshot/mod.rs
@@ -15,6 +15,3 @@ pub use mem_engine::*;
 
 mod iters;
 pub use iters::*;
-
-#[cfg(test)]
-mod test_engine;

--- a/components/epaxos/src/snapshot/traits/mod.rs
+++ b/components/epaxos/src/snapshot/traits/mod.rs
@@ -1,0 +1,5 @@
+mod traits;
+pub use traits::*;
+
+mod test_base;
+pub use test_base::*;

--- a/components/epaxos/src/snapshot/traits/test_base.rs
+++ b/components/epaxos/src/snapshot/traits/test_base.rs
@@ -1,15 +1,8 @@
-use super::errors::*;
-use super::mem_engine::*;
+use super::super::errors::*;
 use super::traits::*;
 use crate::qpaxos::*;
 
-#[test]
-fn test_engine_mem_set_instance() {
-    let mut eng = MemEngine::new().unwrap();
-    test_set_instance(&mut eng);
-}
-
-fn test_set_instance(
+pub fn test_set_instance(
     eng: &mut dyn InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
 ) {
     let leader_id = 2;
@@ -42,13 +35,7 @@ fn test_set_instance(
     assert_eq!(iid, eng.get_ref("exec", leader_id).unwrap());
 }
 
-#[test]
-fn test_engine_mem_get_instance() {
-    let mut eng = MemEngine::new().unwrap();
-    test_get_instance(&mut eng);
-}
-
-fn test_get_instance(
+pub fn test_get_instance(
     eng: &mut dyn InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
 ) {
     let leader_id = 2;
@@ -63,13 +50,7 @@ fn test_get_instance(
     assert_eq!(Some(inst), got);
 }
 
-#[test]
-fn test_engine_mem_next_instance_id() {
-    let mut eng = MemEngine::new().unwrap();
-    test_next_instance_id(&mut eng);
-}
-
-fn test_next_instance_id(
+pub fn test_next_instance_id(
     eng: &mut dyn InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,
 ) {
     let leader_id = 2;

--- a/components/epaxos/src/snapshot/traits/traits.rs
+++ b/components/epaxos/src/snapshot/traits/traits.rs
@@ -4,8 +4,8 @@ use crate::tokey::ToKey;
 // required by encode/decode
 use prost::Message;
 
-use super::Error;
-use super::InstanceIter;
+use super::super::Error;
+use super::super::InstanceIter;
 
 pub struct BaseIter<'a> {
     pub cursor: Vec<u8>,


### PR DESCRIPTION
# Description           <!-- summary, motivation and context -->
调整测试文件的结构：
1.  traits.rs -> traits/traits.rs;
2. test_engine.rs -> traits/test_base.rs;
3. 在 mem_engine/ 的测试里调用 traits/test_base 对各个 traits 接口的测试；


- **Refactoring**
- **Test changes**


# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
