### PR TITLE
feat: add error InvalidRequest; convert Error for transport

### DIFF
--- a/components/epaxos/src/protos/errors.proto
+++ b/components/epaxos/src/protos/errors.proto
@@ -4,8 +4,14 @@ package qpaxos;
 
 message QError {
     StorageFailure sto = 1;
+    InvalidRequest req = 2;
 }
 
 message StorageFailure {
 };
 
+message InvalidRequest {
+    string field = 1;
+    string problem = 2;
+    string ctx = 3;
+};

--- a/components/epaxos/src/qpaxos/t.rs
+++ b/components/epaxos/src/qpaxos/t.rs
@@ -335,31 +335,3 @@ fn test_reply_commit_pb() {
 
     test_enc_dec!(pp, CommitReply);
 }
-
-#[test]
-fn test_reply_err_common() {
-    let inst = new_foo_inst();
-
-    let pp = MakeReply::err_common(&inst, QError { sto: None });
-
-    assert_eq!(None, pp.as_ref().unwrap().last_ballot);
-    assert_eq!(inst.instance_id, pp.as_ref().unwrap().instance_id);
-    assert_eq!(
-        &QError { sto: None },
-        pp.as_ref().unwrap().err.as_ref().unwrap()
-    );
-
-    let pp = MakeReply::err_common(
-        &inst,
-        QError {
-            sto: Some(StorageFailure {}),
-        },
-    );
-
-    assert_eq!(
-        QError {
-            sto: Some(StorageFailure {})
-        },
-        pp.unwrap().err.unwrap()
-    );
-}

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -120,7 +120,13 @@ impl Replica {
                 inst.instance_id = Some(iid);
 
                 CommitReply {
-                    cmn: MakeReply::err_common(&inst, QError { sto: None }),
+                    cmn: MakeReply::err_common(
+                        &inst,
+                        QError {
+                            sto: None,
+                            req: None,
+                        },
+                    ),
                     ..Default::default()
                 }
             }

--- a/components/epaxos/src/snapshot/errors.rs
+++ b/components/epaxos/src/snapshot/errors.rs
@@ -1,3 +1,5 @@
+use crate::qpaxos::{InvalidRequest, QError, StorageFailure};
+
 quick_error! {
     /// Errors occur when set/get with snapshot
     #[derive(Debug, PartialEq)]
@@ -6,6 +8,57 @@ quick_error! {
             from(msg: String) -> {msg: msg}
             display("got db error:{}", msg)
         }
+
         NotFound{}
+
+        NoSuchReplica{
+            replica_id: i64,
+            my_replica_id: i64,
+        } {
+            // from(msg: String) -> {msg: msg}
+            display("no such replica:{}, my replica_id:{}",
+                    replica_id, my_replica_id)
+        }
+        LackOf(field: String) {
+            display("lack of required field:{}",
+                    field)
+        }
+    }
+}
+
+impl Error {
+    pub fn to_qerr(&self) -> QError {
+        match self {
+            Error::DBError { msg: e } => QError {
+                sto: Some(StorageFailure {}),
+                ..Default::default()
+            },
+
+            Self::NotFound {} => QError {
+                sto: Some(StorageFailure {}),
+                ..Default::default()
+            },
+
+            Self::NoSuchReplica {
+                replica_id: rid,
+                my_replica_id: mrid,
+            } => QError {
+                req: Some(InvalidRequest {
+                    field: "to_replica_id".into(),
+                    problem: "NotFound".into(),
+                    ctx: "".into(),
+                }),
+                ..Default::default()
+            },
+
+            Self::LackOf(f) => QError {
+                req: Some(InvalidRequest {
+                    field: f.clone(),
+                    problem: "LackOf".into(),
+                    ctx: "".into(),
+                }),
+                ..Default::default()
+            },
+        }
     }
 }


### PR DESCRIPTION
-   Add qpaxos proto error InvalidRequest to respond a request error.

-   Add two snapshot errors as func return value.

-   Add internal error to qpaxos proto error converter: Error::to_qerr().

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
