### PR TITLE
refactor: simplify handle_commit

### DIFF
--- a/components/epaxos/src/protos/message.proto
+++ b/components/epaxos/src/protos/message.proto
@@ -55,27 +55,31 @@ message PrepareRequest {
 
 message ReplyCommon {
     // The ballot stored on acceptor before handling a request.
-    BallotNum last_ballot = 11;
+
+    BallotNum  last_ballot = 11;
     InstanceID instance_id = 13;
-    QError err = 14;
 }
 message FastAcceptReply {
     // deps_status describe what status a dependent instance is in.
     // Only `deps` needs these information in order to commit on fast-path.
 
-    ReplyCommon cmn = 1;
+    ReplyCommon         cmn            = 1;
+    QError              err            = 5;
     repeated InstanceID deps           = 32;
-    repeated bool                deps_committed = 33;
+    repeated bool       deps_committed = 33;
 }
 message AcceptReply {
     ReplyCommon cmn = 1;
+    QError      err = 5;
 }
 message CommitReply {
     ReplyCommon cmn = 1;
+    QError      err = 5;
 }
 message PrepareReply {
-    ReplyCommon cmn = 1;
+    ReplyCommon         cmn        = 1;
+    QError              err        = 5;
     repeated InstanceID deps       = 32;
     repeated InstanceID final_deps = 41;
-    bool                         committed  = 51;
+    bool                committed  = 51;
 }

--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -169,42 +169,46 @@ impl Instance {
 /// let req = MakeRequest::prepare(some_instance);
 /// ```
 impl MakeRequest {
-    pub fn common(inst: &Instance) -> Option<RequestCommon> {
+    pub fn common(to_replica_id: i64, inst: &Instance) -> Option<RequestCommon> {
         // TODO need filling to_replica_id
         Some(RequestCommon {
-            to_replica_id: 0,
+            to_replica_id,
             ballot: inst.ballot,
             instance_id: inst.instance_id,
         })
     }
 
-    pub fn fast_accept(inst: &Instance, deps_committed: &[bool]) -> FastAcceptRequest {
+    pub fn fast_accept(
+        to_replica_id: i64,
+        inst: &Instance,
+        deps_committed: &[bool],
+    ) -> FastAcceptRequest {
         FastAcceptRequest {
-            cmn: Self::common(inst),
+            cmn: Self::common(to_replica_id, inst),
             cmds: inst.cmds.clone(),
             initial_deps: inst.initial_deps.clone(),
             deps_committed: deps_committed.into(),
         }
     }
 
-    pub fn accept(inst: &Instance) -> AcceptRequest {
+    pub fn accept(to_replica_id: i64, inst: &Instance) -> AcceptRequest {
         AcceptRequest {
-            cmn: Self::common(inst),
+            cmn: Self::common(to_replica_id, inst),
             final_deps: inst.final_deps.clone(),
         }
     }
 
-    pub fn commit(inst: &Instance) -> CommitRequest {
+    pub fn commit(to_replica_id: i64, inst: &Instance) -> CommitRequest {
         CommitRequest {
-            cmn: Self::common(inst),
+            cmn: Self::common(to_replica_id, inst),
             cmds: inst.cmds.clone(),
             final_deps: inst.final_deps.clone(),
         }
     }
 
-    pub fn prepare(inst: &Instance) -> PrepareRequest {
+    pub fn prepare(to_replica_id: i64, inst: &Instance) -> PrepareRequest {
         PrepareRequest {
-            cmn: Self::common(inst),
+            cmn: Self::common(to_replica_id, inst),
         }
     }
 }
@@ -221,21 +225,14 @@ impl MakeReply {
         Some(ReplyCommon {
             last_ballot: inst.last_ballot,
             instance_id: inst.instance_id,
-            err: None,
-        })
-    }
-
-    pub fn err_common(inst: &Instance, err: QError) -> Option<ReplyCommon> {
-        Some(ReplyCommon {
-            last_ballot: None,
-            instance_id: inst.instance_id,
-            err: Some(err),
+            // err: None,
         })
     }
 
     pub fn fast_accept(inst: &Instance, deps_committed: &[bool]) -> FastAcceptReply {
         FastAcceptReply {
             cmn: Self::common(inst),
+            err: None,
             deps: inst.deps.clone(),
             deps_committed: deps_committed.into(),
         }
@@ -244,18 +241,21 @@ impl MakeReply {
     pub fn accept(inst: &Instance) -> AcceptReply {
         AcceptReply {
             cmn: Self::common(inst),
+            err: None,
         }
     }
 
     pub fn commit(inst: &Instance) -> CommitReply {
         CommitReply {
             cmn: Self::common(inst),
+            err: None,
         }
     }
 
     pub fn prepare(inst: &Instance) -> PrepareReply {
         PrepareReply {
             cmn: Self::common(inst),
+            err: None,
             deps: inst.deps.clone(),
             final_deps: inst.final_deps.clone(),
             committed: inst.committed,

--- a/components/epaxos/src/qpaxos/t.rs
+++ b/components/epaxos/src/qpaxos/t.rs
@@ -31,9 +31,10 @@ fn new_foo_inst() -> Instance {
 // TODO test to_replica_id
 
 macro_rules! test_request_common {
-    ($msg:ident, $inst:ident) => {
+    ($msg:ident, $inst:ident, $to_rid:expr) => {
         assert_eq!($inst.ballot, $msg.cmn.as_ref().unwrap().ballot);
         assert_eq!($inst.instance_id, $msg.cmn.as_ref().unwrap().instance_id);
+        assert_eq!($to_rid, $msg.cmn.as_ref().unwrap().to_replica_id);
     };
 }
 
@@ -236,9 +237,9 @@ fn test_instance_after() {
 fn test_request_prepare_pb() {
     let inst = new_foo_inst();
 
-    let pp = MakeRequest::prepare(&inst);
+    let pp = MakeRequest::prepare(100, &inst);
 
-    test_request_common!(pp, inst);
+    test_request_common!(pp, inst, 100);
     // prepare has no other fields.
 
     test_enc_dec!(pp, PrepareRequest);
@@ -263,9 +264,9 @@ fn test_request_fast_accpt_pb() {
     let inst = new_foo_inst();
 
     let deps_committed = &[true, false];
-    let pp = MakeRequest::fast_accept(&inst, deps_committed);
+    let pp = MakeRequest::fast_accept(100, &inst, deps_committed);
 
-    test_request_common!(pp, inst);
+    test_request_common!(pp, inst, 100);
     assert_eq!(inst.cmds, pp.cmds);
     assert_eq!(inst.initial_deps, pp.initial_deps);
     assert_eq!(deps_committed.to_vec(), pp.deps_committed);
@@ -291,9 +292,9 @@ fn test_reply_fast_accept_pb() {
 fn test_request_accept_pb() {
     let inst = new_foo_inst();
 
-    let pp = MakeRequest::accept(&inst);
+    let pp = MakeRequest::accept(100, &inst);
 
-    test_request_common!(pp, inst);
+    test_request_common!(pp, inst, 100);
     assert_eq!(inst.final_deps, pp.final_deps);
 
     test_enc_dec!(pp, AcceptRequest);
@@ -315,9 +316,9 @@ fn test_reply_accept_pb() {
 fn test_request_commit_pb() {
     let inst = new_foo_inst();
 
-    let pp = MakeRequest::commit(&inst);
+    let pp = MakeRequest::commit(100, &inst);
 
-    test_request_common!(pp, inst);
+    test_request_common!(pp, inst, 100);
     assert_eq!(inst.cmds, pp.cmds);
     assert_eq!(inst.final_deps, pp.final_deps);
 

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -184,16 +184,11 @@ impl Replica {
             });
         }
 
-        let ballot = match cm.ballot {
-            Some(v) => v,
-            None => return Err(Error::LackOf("cmn.ballot".into())),
-        };
+        let ballot = cm.ballot.ok_or(Error::LackOf("cmn.ballot".into()))?;
 
-        let iid = cm.instance_id;
-        let iid = match iid {
-            Some(v) => v,
-            None => return Err(Error::LackOf("cmn.instance_id".into())),
-        };
+        let iid = cm
+            .instance_id
+            .ok_or(Error::LackOf("cmn.instance_id".into()))?;
 
         Ok((ballot, iid))
     }

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -53,28 +53,22 @@ fn test_handle_commit_request() {
     let none = replica.storage.get_instance(iid).unwrap();
     assert_eq!(None, none);
 
-    let req = MakeRequest::commit(&inst);
+    let req = MakeRequest::commit(replica_id, &inst);
 
     {
         // ok reply with none instance.
         let repl = replica.handle_commit(&req);
+        assert_eq!(None, repl.err);
         let cmn = repl.cmn.unwrap();
         assert_eq!(iid, cmn.instance_id.unwrap());
-        assert_eq!(
-            BallotNum::from((0, 0, replica_id)),
-            cmn.last_ballot.unwrap()
-        );
-        assert_eq!(None, cmn.err);
+        assert_eq!(None, cmn.last_ballot);
 
         // get the committed instance.
         let inst = replica.storage.get_instance(iid).unwrap();
         let inst = inst.unwrap();
         assert_eq!(iid, inst.instance_id.unwrap());
         assert_eq!(blt, inst.ballot.unwrap());
-        assert_eq!(
-            BallotNum::from((0, 0, replica_id)),
-            inst.last_ballot.unwrap()
-        );
+        assert_eq!(None, inst.last_ballot);
         assert_eq!(cmds, inst.cmds);
         assert_eq!(fdeps, inst.final_deps);
     }
@@ -82,10 +76,10 @@ fn test_handle_commit_request() {
     {
         // ok reply when replacing instance.
         let repl = replica.handle_commit(&req);
+        assert_eq!(None, repl.err);
         let cmn = repl.cmn.unwrap();
         assert_eq!(iid, inst.instance_id.unwrap());
         assert_eq!(blt, cmn.last_ballot.unwrap());
-        assert_eq!(None, cmn.err);
 
         // get the committed instance.
         let inst = replica.storage.get_instance(iid).unwrap();

--- a/components/epaxos/tests/test_repl_server.rs
+++ b/components/epaxos/tests/test_repl_server.rs
@@ -54,7 +54,7 @@ async fn _repl_server() {
 
     // let request = Request::new(message::Request::accept());
     // let request = message::Request::accept().into();
-    let request = qp::MakeRequest::accept(&inst);
+    let request = qp::MakeRequest::accept(0, &inst);
 
     let response = client.accept(request).await.unwrap();
 

--- a/tests/test_setget.rs
+++ b/tests/test_setget.rs
@@ -45,7 +45,7 @@ async fn connect_repl() {
         ..Default::default()
     };
 
-    let request = MakeRequest::accept(&inst);
+    let request = MakeRequest::accept(0, &inst);
 
     let response = client.accept(request).await.unwrap();
 


### PR DESCRIPTION
-   proto: move err out of ReplyCommon, as a standalone field in XXXReply.

-   Remove MakeRequest::err_common().

-   MakeRequest add arg to_replica_id to specify where to send.

-   Simpilfy handle_xxx() error handling with Error::to_qerror().

-   Impl handle_accept(), without test yet. TODO

-   Add request check.

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**
- **Test changes**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
