### PR TITLE
refactor: epaxos: adjust test file locations

### DIFF
--- a/components/epaxos/src/snapshot/mod.rs
+++ b/components/epaxos/src/snapshot/mod.rs
@@ -15,3 +15,9 @@ pub use mem_engine::*;
 
 mod iters;
 pub use iters::*;
+
+#[cfg(test)]
+mod test_engine;
+
+#[cfg(test)]
+use test_engine::*;

--- a/components/epaxos/src/snapshot/rocks_engine/test_engine.rs
+++ b/components/epaxos/src/snapshot/rocks_engine/test_engine.rs
@@ -2,6 +2,7 @@ use tempfile::Builder;
 
 use super::super::traits::*;
 use super::super::RocksDBEngine;
+use crate::snapshot::test_engine::*;
 
 #[test]
 fn test_base() {

--- a/components/epaxos/src/snapshot/test_engine.rs
+++ b/components/epaxos/src/snapshot/test_engine.rs
@@ -1,6 +1,6 @@
-use super::super::errors::*;
 use super::traits::*;
 use crate::qpaxos::*;
+use crate::snapshot::errors::*;
 
 pub fn test_set_instance(
     eng: &mut dyn InstanceEngine<ColumnId = ReplicaID, Obj = Instance, ObjId = InstanceID>,

--- a/components/epaxos/src/snapshot/traits/mod.rs
+++ b/components/epaxos/src/snapshot/traits/mod.rs
@@ -1,5 +1,2 @@
 mod traits;
 pub use traits::*;
-
-mod test_base;
-pub use test_base::*;


### PR DESCRIPTION
Rename:

Before: snapshot/traits/test_base.rs
After : snapshot/test_engine.rs

`test_base.rs` actually test all engine trait, not only the `Base`
trait, and it is not test for trait but for trait impl.



## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
