### PR TITLE
feat: add InstanceIdVec as wrapper of Vec<InstanceId>

### DIFF
--- a/components/epaxos/src/protos/instance.proto
+++ b/components/epaxos/src/protos/instance.proto
@@ -9,6 +9,10 @@ message InstanceID {
     int64 idx = 2;
 };
 
+message InstanceIdVec {
+    repeated InstanceID ids = 1;
+}
+
 enum InstanceStatus {
     NA = 0;
     PreAccepted = 1;

--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -1,3 +1,5 @@
+use std::ops::Index;
+use std::ops::{Deref, DerefMut};
 use tonic;
 use tonic::{Request, Response, Status};
 
@@ -121,6 +123,49 @@ impl InstanceID {
         }
 
         return None;
+    }
+}
+
+/// Let user use method of Vec<InstanceId> directly.
+impl Deref for InstanceIdVec {
+    type Target = Vec<InstanceId>;
+    fn deref(&self) -> &Self::Target {
+        &self.ids
+    }
+}
+
+/// Let user use method of Vec<InstanceId> directly.
+impl DerefMut for InstanceIdVec {
+    fn deref_mut(&mut self) -> &mut Vec<InstanceId> {
+        &mut self.ids
+    }
+}
+
+/// Let user use instance_id_vec[replic_id] to retreive an instance_id.
+/// It panics if replica_id not found.
+/// It returns the first match.
+impl Index<ReplicaID> for InstanceIdVec {
+    type Output = InstanceId;
+    fn index(&self, rid: ReplicaID) -> &Self::Output {
+        for inst in self.ids.iter() {
+            if inst.replica_id == rid {
+                return inst;
+            }
+        }
+        panic!("NotFound instance_id with replica_id={}", rid);
+    }
+}
+
+impl InstanceIdVec {
+    /// get retreive an instance_id with specified replica_id.
+    /// It returns the first match.
+    fn get(&self, rid: ReplicaID) -> Option<InstanceId> {
+        for inst in self.ids.iter() {
+            if inst.replica_id == rid {
+                return Some(*inst);
+            }
+        }
+        None
     }
 }
 

--- a/components/epaxos/src/qpaxos/test_instance.rs
+++ b/components/epaxos/src/qpaxos/test_instance.rs
@@ -36,3 +36,69 @@ fn test_instance_conflict() {
 
     assert!(gxsy.conflict(&gxsy));
 }
+
+#[test]
+fn test_instance_id_vec_deref() {
+    let ids = InstanceIdVec {
+        ids: vec![(1, 2).into(), (3, 4).into()],
+    };
+
+    let mut it = ids.iter();
+    assert_eq!(&ids.ids[0], it.next().unwrap());
+    assert_eq!(&ids.ids[1], it.next().unwrap());
+    assert_eq!(None, it.next());
+
+    let mut ids = InstanceIdVec {
+        ids: vec![(1, 2).into(), (3, 4).into()],
+    };
+
+    let mut it = ids.iter_mut();
+    assert_eq!(&InstanceID::from((1, 2)), it.next().unwrap());
+    assert_eq!(&InstanceID::from((3, 4)), it.next().unwrap());
+    assert_eq!(None, it.next());
+}
+
+#[test]
+fn test_instance_id_vec_index() {
+    let ids = InstanceIdVec {
+        ids: vec![(1, 2).into(), (3, 4).into()],
+    };
+
+    assert_eq!(ids.ids[0], ids[1]);
+    assert_eq!(ids.ids[1], ids[3]);
+}
+
+#[test]
+#[should_panic(expect = "NotFound instance_id with replica_id=2")]
+fn test_instance_id_vec_index_panic() {
+    let ids = InstanceIdVec {
+        ids: vec![(1, 2).into(), (3, 4).into()],
+    };
+
+    let _ = ids[2];
+}
+
+#[test]
+fn test_instance_id_vec_get() {
+    let ids = InstanceIdVec {
+        ids: vec![(1, 2).into(), (3, 4).into()],
+    };
+
+    assert_eq!(ids.ids[0], ids.get(1).unwrap());
+    assert_eq!(ids.ids[1], ids.get(3).unwrap());
+    assert_eq!(None, ids.get(2));
+}
+
+#[test]
+fn test_instance_id_vec_with_dup() {
+    let ids = InstanceIdVec {
+        ids: vec![(1, 2).into(), (3, 4).into(), (1, 100).into()],
+    };
+
+    assert_eq!(ids.ids[0], ids.get(1).unwrap());
+    assert_eq!(ids.ids[1], ids.get(3).unwrap());
+    assert_eq!(None, ids.get(2));
+
+    assert_eq!(ids.ids[0], ids[1]);
+    assert_eq!(ids.ids[1], ids[3]);
+}


### PR DESCRIPTION
-   InstanceIdVec impl trait Deref thus it can be used the same way as
    with `Vec<InstanceId>`.

-   InstanceIdVec also impl trait Index, to get InstanceId by ReplicaID
    just like accessing a Vec: `instance_id_vec[replica_id]`.

    It panics if specified replica id not found, just like accessing an
    absent key on a BTreeMap.

-   InstanceIdVec provides a `get(rid: ReplicaID)` method to safely get
    an `Option<InstanceID>`.


## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
