### PR TITLE
feat: InstanceIdVec: add a lot From<...> impl

### DIFF
--- a/components/epaxos/build.rs
+++ b/components/epaxos/build.rs
@@ -13,6 +13,7 @@ fn main() {
             "InstanceId",
             "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]",
         )
+        .type_attribute("InstanceIdVec", "#[derive(derive_more::From)]")
         .type_attribute(
             "BallotNum",
             "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]",

--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -166,6 +166,64 @@ impl InstanceIdVec {
     }
 }
 
+impl From<&[InstanceId]> for InstanceIdVec {
+    fn from(v: &[InstanceId]) -> InstanceIdVec {
+        InstanceIdVec { ids: v.into() }
+    }
+}
+
+impl<A: Into<ReplicaID> + Copy, B: Into<i64> + Copy> From<&[(A, B)]> for InstanceIdVec {
+    fn from(v: &[(A, B)]) -> InstanceIdVec {
+        let x: Vec<InstanceId> = v
+            .iter()
+            .map(|x| InstanceId {
+                replica_id: x.0.into(),
+                idx: x.1.into(),
+            })
+            .collect();
+        x.to_vec().into()
+    }
+}
+
+impl<A> From<&[A; 0]> for InstanceIdVec {
+    fn from(_v: &[A; 0]) -> InstanceIdVec {
+        InstanceIdVec { ids: vec![] }
+    }
+}
+
+impl<A> From<[A; 0]> for InstanceIdVec {
+    fn from(_v: [A; 0]) -> InstanceIdVec {
+        InstanceIdVec { ids: vec![] }
+    }
+}
+
+macro_rules! impl_instance_id_vec {
+    ($n:expr) => {
+        impl<A: Into<ReplicaID> + Copy, B: Into<i64> + Copy> From<&[(A, B); $n]> for InstanceIdVec {
+            fn from(v: &[(A, B); $n]) -> InstanceIdVec {
+                let q: &[_] = v;
+                q.into()
+            }
+        }
+
+        impl<A: Into<ReplicaID> + Copy, B: Into<i64> + Copy> From<[(A, B); $n]> for InstanceIdVec {
+            fn from(v: [(A, B); $n]) -> InstanceIdVec {
+                let q: &[_] = &v;
+                q.into()
+            }
+        }
+    };
+}
+
+impl_instance_id_vec!(1);
+impl_instance_id_vec!(2);
+impl_instance_id_vec!(3);
+impl_instance_id_vec!(4);
+impl_instance_id_vec!(5);
+impl_instance_id_vec!(6);
+impl_instance_id_vec!(7);
+impl_instance_id_vec!(8);
+
 impl ToKey for Instance {
     fn to_key(&self) -> Vec<u8> {
         self.instance_id.as_ref().unwrap().to_key()

--- a/components/epaxos/src/qpaxos/test_instance.rs
+++ b/components/epaxos/src/qpaxos/test_instance.rs
@@ -69,7 +69,7 @@ fn test_instance_id_vec_index() {
 }
 
 #[test]
-#[should_panic(expect = "NotFound instance_id with replica_id=2")]
+#[should_panic(expected = "NotFound instance_id with replica_id=2")]
 fn test_instance_id_vec_index_panic() {
     let ids = InstanceIdVec {
         ids: vec![(1, 2).into(), (3, 4).into()],
@@ -101,4 +101,122 @@ fn test_instance_id_vec_with_dup() {
 
     assert_eq!(ids.ids[0], ids[1]);
     assert_eq!(ids.ids[1], ids[3]);
+}
+
+#[test]
+fn test_instance_id_vec_from() {
+    let iid = InstanceId::from((1, 2));
+
+    let sl: &[_] = &[iid];
+    let ids: InstanceIdVec = sl.into();
+    assert_eq!(iid, ids[1]);
+
+    let ids: InstanceIdVec = vec![iid].into();
+    assert_eq!(iid, ids[1]);
+
+    let sl: &[_] = &[(1, 2), (3, 4)];
+    let ids: InstanceIdVec = sl.into();
+    assert_eq!(iid, ids[1]);
+
+    let sl: &[(i32, i64)] = &[(1, 2), (3, 4)];
+    let ids: InstanceIdVec = sl.into();
+    assert_eq!(iid, ids[1]);
+}
+
+#[test]
+fn test_instance_id_vec_from_array() {
+    let iid = InstanceId::from((1, 2));
+
+    let arr: [i32; 0] = [];
+    let ids: InstanceIdVec = arr.into();
+
+    let arr = [(1, 2)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = [(1, 2), (3, 4)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = [(1, 2), (3, 4), (5, 6)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = [(1, 2), (3, 4), (5, 6), (7, 8)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = [(1, 2), (3, 4), (5, 6), (7, 8), (9, 10)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = [(1, 2), (3, 4), (5, 6), (7, 8), (9, 10), (11, 12)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = [(1, 2), (3, 4), (5, 6), (7, 8), (9, 10), (11, 12), (13, 14)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = [
+        (1, 2),
+        (3, 4),
+        (5, 6),
+        (7, 8),
+        (9, 10),
+        (11, 12),
+        (13, 14),
+        (15, 16),
+    ];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+}
+
+#[test]
+fn test_instance_id_vec_from_array_ref() {
+    let iid = InstanceId::from((1, 2));
+
+    let arr: &[i32; 0] = &[];
+    let ids: InstanceIdVec = arr.into();
+
+    let arr = &[(1, 2)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = &[(1, 2), (3, 4)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = &[(1, 2), (3, 4), (5, 6)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = &[(1, 2), (3, 4), (5, 6), (7, 8)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = &[(1, 2), (3, 4), (5, 6), (7, 8), (9, 10)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = &[(1, 2), (3, 4), (5, 6), (7, 8), (9, 10), (11, 12)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = &[(1, 2), (3, 4), (5, 6), (7, 8), (9, 10), (11, 12), (13, 14)];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
+
+    let arr = &[
+        (1, 2),
+        (3, 4),
+        (5, 6),
+        (7, 8),
+        (9, 10),
+        (11, 12),
+        (13, 14),
+        (15, 16),
+    ];
+    let ids: InstanceIdVec = arr.into();
+    assert_eq!(iid, ids[1]);
 }


### PR DESCRIPTION
- `From<Vec<InstanceID>>`
- `From<&[InstanceID]>>`
- `From<[({int}, {int})]>>` requires {int} to be a type that can be converted into ReplicaID and i64.
- `From<&[({int}, {int})]>>`
- From empty array/slice
- From array or ref of array with length 1~8.

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
