### PR TITLE
Use instanceIdVec

### DIFF
--- a/components/epaxos/src/protos/instance.proto
+++ b/components/epaxos/src/protos/instance.proto
@@ -36,16 +36,16 @@ message Instance {
     repeated Command cmds  = 21;
 
     // initial_deps is the dependent instance ids when an instance is created.
-    repeated InstanceId initial_deps                = 31;
+    InstanceIdVec initial_deps                = 31;
 
     // deps is the updated instance ids on a replica when handling PreAccept
     // request.
     // When an instance is intiated, it is same as initial_deps.
-    repeated InstanceId deps                        = 32;
+    InstanceIdVec deps                        = 32;
 
     // final_deps is the final dependency chosen by instance leader or recover
     // process, and is set by Accept request or Commit request.
-    repeated InstanceId final_deps                  = 41;
+    InstanceIdVec final_deps                  = 41;
 
     // An instance has several status thus one status field is not enough.
     // To determine the instance status:

--- a/components/epaxos/src/protos/message.proto
+++ b/components/epaxos/src/protos/message.proto
@@ -33,17 +33,17 @@ message RequestCommon {
 message FastAcceptRequest {
     RequestCommon cmn = 1;
     repeated Command     cmds           = 21;
-    repeated InstanceId initial_deps   = 31;
+    InstanceIdVec        initial_deps   = 31;
     repeated bool                deps_committed = 33;
 }
 message AcceptRequest {
     RequestCommon cmn = 1;
-    repeated InstanceId final_deps     = 41;
+    InstanceIdVec final_deps = 41;
 }
 message CommitRequest {
     RequestCommon cmn = 1;
     repeated Command     cmds           = 21;
-    repeated InstanceId final_deps     = 41;
+    InstanceIdVec        final_deps     = 41;
 }
 message PrepareRequest {
     RequestCommon cmn = 1;
@@ -65,7 +65,7 @@ message FastAcceptReply {
 
     ReplyCommon         cmn            = 1;
     QError              err            = 5;
-    repeated InstanceId deps           = 32;
+    InstanceIdVec       deps           = 32;
     repeated bool       deps_committed = 33;
 }
 message AcceptReply {
@@ -79,7 +79,7 @@ message CommitReply {
 message PrepareReply {
     ReplyCommon         cmn        = 1;
     QError              err        = 5;
-    repeated InstanceId deps       = 32;
-    repeated InstanceId final_deps = 41;
+    InstanceIdVec       deps       = 32;
+    InstanceIdVec       final_deps = 41;
     bool                committed  = 51;
 }

--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -260,24 +260,18 @@ impl Instance {
         let mut great = false;
         // TODO unwrap
         for iid in other.final_deps.as_ref().unwrap().iter() {
-            match self
-                .final_deps
-                // TODO unwrap
-                .as_ref()
-                .unwrap()
-                .iter()
-                .find(|x| x.replica_id == iid.replica_id)
-            {
-                Some(my_iid) => {
-                    if my_iid.idx < iid.idx {
-                        return false;
-                    }
-
-                    if my_iid.idx > iid.idx {
-                        great = true;
-                    }
-                }
+            // TODO unwrap
+            let myiid = self.final_deps.as_ref().unwrap().get(iid.replica_id);
+            let myiid = match myiid {
+                Some(v) => v,
                 None => continue,
+            };
+
+            if myiid.idx < iid.idx {
+                return false;
+            }
+            if myiid.idx > iid.idx {
+                great = true;
             }
         }
 

--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -251,16 +251,20 @@ impl Instance {
         Instance {
             cmds: cmds.into(),
             ballot: Some(ballot),
-            initial_deps: deps.into(),
+            initial_deps: Some(deps.into()),
             ..Default::default()
         }
     }
 
     pub fn after(&self, other: &Instance) -> bool {
         let mut great = false;
-        for iid in other.final_deps.iter() {
+        // TODO unwrap
+        for iid in other.final_deps.as_ref().unwrap().iter() {
             match self
                 .final_deps
+                // TODO unwrap
+                .as_ref()
+                .unwrap()
                 .iter()
                 .find(|x| x.replica_id == iid.replica_id)
             {

--- a/components/epaxos/src/qpaxos/t.rs
+++ b/components/epaxos/src/qpaxos/t.rs
@@ -21,8 +21,8 @@ fn new_foo_inst() -> Instance {
     let mut inst = Instance::of(&cmds[..], ballot, &initial_deps[..]);
     // TODO move these to Instance::new_instance
     inst.instance_id = Some(inst_id1);
-    inst.deps = [inst_id2].to_vec();
-    inst.final_deps = [inst_id3].to_vec();
+    inst.deps = Some(vec![inst_id2].into());
+    inst.final_deps = Some(vec![inst_id3].into());
     inst.last_ballot = Some(ballot2);
 
     inst
@@ -151,77 +151,77 @@ fn test_instance_after() {
     let cases = vec![
         (
             Instance {
-                final_deps: vec![(1, 1).into()],
+                final_deps: Some([(1, 1)].into()),
                 ..Default::default()
             },
             Instance {
-                final_deps: vec![(1, 1).into()],
+                final_deps: Some([(1, 1)].into()),
                 ..Default::default()
             },
             false,
         ),
         (
             Instance {
-                final_deps: vec![(1, 1).into()],
+                final_deps: Some([(1, 1)].into()),
                 ..Default::default()
             },
             Instance {
-                final_deps: vec![(1, 0).into()],
+                final_deps: Some([(1, 0)].into()),
                 ..Default::default()
             },
             true,
         ),
         (
             Instance {
-                final_deps: vec![(1, 1).into(), (2, 1).into()],
+                final_deps: Some([(1, 1), (2, 1)].into()),
                 ..Default::default()
             },
             Instance {
-                final_deps: vec![(1, 1).into(), (2, 1).into()],
+                final_deps: Some([(1, 1), (2, 1)].into()),
                 ..Default::default()
             },
             false,
         ),
         (
             Instance {
-                final_deps: vec![(1, 1).into(), (2, 1).into()],
+                final_deps: Some([(1, 1), (2, 1)].into()),
                 ..Default::default()
             },
             Instance {
-                final_deps: vec![(1, 1).into(), (2, 0).into()],
+                final_deps: Some([(1, 1), (2, 0)].into()),
                 ..Default::default()
             },
             true,
         ),
         (
             Instance {
-                final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 1).into()],
+                final_deps: Some([(1, 1), (2, 1), (3, 1)].into()),
                 ..Default::default()
             },
             Instance {
-                final_deps: vec![(1, 1).into(), (2, 1).into()],
-                ..Default::default()
-            },
-            false,
-        ),
-        (
-            Instance {
-                final_deps: vec![(1, 1).into(), (2, 1).into()],
-                ..Default::default()
-            },
-            Instance {
-                final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 1).into()],
+                final_deps: Some([(1, 1), (2, 1)].into()),
                 ..Default::default()
             },
             false,
         ),
         (
             Instance {
-                final_deps: vec![(1, 2).into(), (2, 1).into()],
+                final_deps: Some([(1, 1), (2, 1)].into()),
                 ..Default::default()
             },
             Instance {
-                final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 1).into()],
+                final_deps: Some([(1, 1), (2, 1), (3, 1)].into()),
+                ..Default::default()
+            },
+            false,
+        ),
+        (
+            Instance {
+                final_deps: Some([(1, 2), (2, 1)].into()),
+                ..Default::default()
+            },
+            Instance {
+                final_deps: Some([(1, 1), (2, 1), (3, 1)].into()),
                 ..Default::default()
             },
             true,

--- a/components/epaxos/src/qpaxos/test_instance.rs
+++ b/components/epaxos/src/qpaxos/test_instance.rs
@@ -87,6 +87,18 @@ fn test_instance_id_vec_get() {
     assert_eq!(ids.ids[0], ids.get(1).unwrap());
     assert_eq!(ids.ids[1], ids.get(3).unwrap());
     assert_eq!(None, ids.get(2));
+
+    let refids = &ids;
+    assert_eq!(ids.ids[0], refids.get(1).unwrap());
+    assert_eq!(ids.ids[1], refids.get(3).unwrap());
+    assert_eq!(None, ids.get(2));
+
+    let sm = Some(ids.clone());
+    let refids = sm.as_ref().unwrap();
+
+    assert_eq!(ids.ids[0], refids.get(1i64).unwrap());
+    assert_eq!(ids.ids[1], refids.get(3).unwrap());
+    assert_eq!(None, refids.get(2));
 }
 
 #[test]

--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -33,7 +33,8 @@ impl Replica {
         let mut rst: Vec<InstanceId> = Vec::new();
 
         for inst in min_insts {
-            for dep_inst_id in inst.final_deps.iter() {
+            // TODO unwrap would panic
+            for dep_inst_id in inst.final_deps.as_ref().unwrap().iter() {
                 if let Some(_) = min_insts.iter().find(|x| match &x.instance_id {
                     Some(iid) => return iid.replica_id == dep_inst_id.replica_id,
                     None => return false,

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -17,8 +17,8 @@ fn new_foo_inst(leader_id: i64) -> Instance {
     let mut inst = Instance::of(&cmds[..], ballot, &initial_deps[..]);
     // TODO move these to Instance::new_instance
     inst.instance_id = Some((leader_id, 1).into());
-    inst.deps = [iid2].to_vec();
-    inst.final_deps = [iid3].to_vec();
+    inst.deps = Some([iid2].to_vec().into());
+    inst.final_deps = Some([iid3].to_vec().into());
     inst.last_ballot = Some(ballot2);
 
     inst
@@ -124,7 +124,7 @@ fn test_handle_fast_accept_request() {
         _test_repl_cmn_ok(&repl.cmn.unwrap(), iid, blt);
 
         // get the written instance.
-        _test_get_inst(&replica, iid, blt, blt, inst.cmds, vec![]);
+        _test_get_inst(&replica, iid, blt, blt, inst.cmds, None);
     }
 
     {
@@ -147,7 +147,7 @@ fn test_handle_fast_accept_request() {
         let initial_deps = vec![];
 
         let mut instx = Instance::of(&cmds[..], ballot, &initial_deps[..]);
-        instx.deps = vec![(0, 0).into(), (0, 0).into(), (0, 0).into()];
+        instx.deps = Some([(0, 0), (0, 0), (0, 0)].into());
         instx.instance_id = Some(x_iid);
         replica.storage.set_instance(&instx).unwrap();
 
@@ -159,7 +159,7 @@ fn test_handle_fast_accept_request() {
         let initial_deps = vec![];
 
         let mut insty = Instance::of(&cmds[..], ballot, &initial_deps[..]);
-        insty.deps = vec![(0, 0).into(), (0, 0).into(), (0, 0).into()];
+        insty.deps = Some([(0, 0), (0, 0), (0, 0)].into());
         insty.instance_id = Some(y_iid);
         replica.storage.set_instance(&insty).unwrap();
 
@@ -171,7 +171,7 @@ fn test_handle_fast_accept_request() {
         let initial_deps = vec![];
 
         let mut instz = Instance::of(&cmds[..], ballot, &initial_deps[..]);
-        instz.deps = vec![(0, 0).into(), (0, 0).into(), (0, 0).into()];
+        instz.deps = Some([(0, 0), (0, 0), (0, 0)].into());
         instz.instance_id = Some(z_iid);
         replica.storage.set_instance(&instz).unwrap();
 
@@ -183,7 +183,7 @@ fn test_handle_fast_accept_request() {
         let initial_deps = vec![];
 
         let mut instb = Instance::of(&cmds[..], ballot, &initial_deps[..]);
-        instb.deps = vec![x_iid, y_iid, z_iid];
+        instb.deps = Some(vec![x_iid, y_iid, z_iid].into());
         instb.instance_id = Some(b_iid);
         instb.committed = true;
         replica.storage.set_instance(&instb).unwrap();
@@ -196,7 +196,7 @@ fn test_handle_fast_accept_request() {
         let initial_deps = vec![x_iid, y_iid, z_iid];
 
         let mut insta = Instance::of(&cmds[..], ballot, &initial_deps[..]);
-        insta.deps = vec![x_iid, y_iid, z_iid];
+        insta.deps = Some(vec![x_iid, y_iid, z_iid].into());
         insta.instance_id = Some(a_iid);
 
         // instd
@@ -207,7 +207,7 @@ fn test_handle_fast_accept_request() {
         let initial_deps = vec![];
 
         let mut instd = Instance::of(&cmds[..], ballot, &initial_deps[..]);
-        instd.deps = vec![a_iid, b_iid, z_iid];
+        instd.deps = Some(vec![a_iid, b_iid, z_iid].into());
         instd.instance_id = Some(d_iid);
         replica.storage.set_instance(&instd).unwrap();
 
@@ -219,7 +219,7 @@ fn test_handle_fast_accept_request() {
         let initial_deps = vec![];
 
         let mut instc = Instance::of(&cmds[..], ballot, &initial_deps[..]);
-        instc.deps = vec![d_iid, b_iid, z_iid];
+        instc.deps = Some(vec![d_iid, b_iid, z_iid].into());
         instc.instance_id = Some(c_iid);
         replica.storage.set_instance(&instc).unwrap();
 
@@ -227,7 +227,7 @@ fn test_handle_fast_accept_request() {
         let req = MakeRequest::fast_accept(replica_id, &insta, &deps_committed);
         let repl = replica.handle_fast_accept(&req);
 
-        insta.deps = vec![x_iid, b_iid, z_iid];
+        insta.deps = Some(vec![x_iid, b_iid, z_iid].into());
 
         assert_eq!(None, repl.err);
         assert_eq!(deps_committed, repl.deps_committed);
@@ -242,7 +242,7 @@ fn test_handle_fast_accept_request() {
             insta.ballot,
             insta.ballot,
             insta.cmds,
-            vec![],
+            None,
         );
     }
 }
@@ -297,7 +297,7 @@ fn test_handle_accept_request() {
         let bigger = Some(bigger);
 
         curr.ballot = bigger;
-        curr.final_deps = vec![];
+        curr.final_deps = Some(vec![].into());
         replica.storage.set_instance(&curr).unwrap();
 
         let curr = replica.storage.get_instance(iid).unwrap().unwrap();
@@ -309,7 +309,7 @@ fn test_handle_accept_request() {
         _test_repl_cmn_ok(&repl.cmn.unwrap(), iid, bigger);
 
         // get the intact instance.
-        _test_get_inst(&replica, iid, bigger, blt, vec![], vec![]);
+        _test_get_inst(&replica, iid, bigger, blt, vec![], Some(vec![].into()));
     }
 
     // TODO test storage error
@@ -364,7 +364,7 @@ fn _test_get_inst(
     blt: Option<BallotNum>,
     last: Option<BallotNum>,
     cmds: Vec<Command>,
-    final_deps: Vec<InstanceId>,
+    final_deps: Option<InstanceIdVec>,
 ) {
     let got = replica.storage.get_instance(iid).unwrap().unwrap();
     assert_eq!(iid, got.instance_id.unwrap());

--- a/components/epaxos/src/replica/tests/exec_tests.rs
+++ b/components/epaxos/src/replica/tests/exec_tests.rs
@@ -26,7 +26,7 @@ fn test_find_missing_instances() {
         (
             vec![Instance {
                 instance_id: Some((1, 2).into()),
-                final_deps: vec![(1, 1).into()],
+                final_deps: Some([(1, 1)].into()),
                 ..Default::default()
             }],
             vec![InstanceId::from((1, 1))],
@@ -43,12 +43,12 @@ fn test_find_missing_instances() {
             vec![
                 Instance {
                     instance_id: Some((1, 2).into()),
-                    final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 3).into()],
+                    final_deps: Some([(1, 1), (2, 1), (3, 3)].into()),
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((2, 2).into()),
-                    final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 5).into()],
+                    final_deps: Some([(1, 1), (2, 1), (3, 5)].into()),
                     ..Default::default()
                 },
             ],
@@ -77,7 +77,7 @@ fn test_find_missing_instances() {
         (
             vec![Instance {
                 instance_id: Some((1, 2).into()),
-                final_deps: vec![(1, 1).into(), (2, 6).into(), (3, 6).into()],
+                final_deps: Some([(1, 1), (2, 6), (3, 6)].into()),
                 ..Default::default()
             }],
             vec![InstanceId::from((1, 1)), (2, 5).into(), (3, 5).into()],
@@ -97,12 +97,12 @@ fn test_find_missing_instances() {
             vec![
                 Instance {
                     instance_id: Some((1, 2).into()),
-                    final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 1).into()],
+                    final_deps: Some([(1, 1), (2, 1), (3, 1)].into()),
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((2, 2).into()),
-                    final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 3).into()],
+                    final_deps: Some([(1, 1), (2, 1), (3, 3)].into()),
                     ..Default::default()
                 },
             ],
@@ -205,19 +205,19 @@ fn test_execute_instances() {
         Instance {
             instance_id: Some((1, 1).into()),
             cmds: vec![Command::of(OpCode::Set, &[2], &[222])],
-            final_deps: vec![(1, 0).into(), (2, 0).into(), (3, 0).into()],
+            final_deps: Some([(1, 0), (2, 0), (3, 0)].into()),
             ..Default::default()
         },
         Instance {
             instance_id: Some(InstanceId::from((2, 1))),
             cmds: vec![Command::of(OpCode::NoOp, &[], &[])],
-            final_deps: vec![(1, 1).into(), (2, 0).into(), (3, 0).into()],
+            final_deps: Some([(1, 1), (2, 0), (3, 0)].into()),
             ..Default::default()
         },
         Instance {
             instance_id: Some((3, 1).into()),
             cmds: vec![Command::of(OpCode::Set, &[1], &[11])],
-            final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 0).into()],
+            final_deps: Some([(1, 1), (2, 1), (3, 0)].into()),
             ..Default::default()
         },
     ];
@@ -232,19 +232,19 @@ fn test_execute_instances() {
         Instance {
             instance_id: Some((1, 1).into()),
             cmds: vec![Command::of(OpCode::Set, &[2], &[222])],
-            final_deps: vec![(1, 0).into(), (2, 1).into(), (3, 0).into()],
+            final_deps: Some([(1, 0), (2, 1), (3, 0)].into()),
             ..Default::default()
         },
         Instance {
             instance_id: Some(InstanceId::from((2, 1))),
             cmds: vec![Command::of(OpCode::NoOp, &[], &[])],
-            final_deps: vec![(1, 1).into(), (2, 0).into(), (3, 0).into()],
+            final_deps: Some([(1, 1), (2, 0), (3, 0)].into()),
             ..Default::default()
         },
         Instance {
             instance_id: Some((3, 1).into()),
             cmds: vec![Command::of(OpCode::Set, &[1], &[11])],
-            final_deps: vec![(1, 1).into(), (2, 0).into(), (3, 0).into()],
+            final_deps: Some([(1, 1), (2, 0), (3, 0)].into()),
             ..Default::default()
         },
     ];
@@ -264,19 +264,19 @@ fn test_execute_instances() {
         Instance {
             instance_id: Some((1, 1).into()),
             cmds: vec![Command::of(OpCode::Set, &[2], &[222])],
-            final_deps: vec![(1, 0).into(), (2, 1).into(), (3, 0).into()],
+            final_deps: Some([(1, 0), (2, 1), (3, 0)].into()),
             ..Default::default()
         },
         Instance {
             instance_id: Some(InstanceId::from((2, 1))),
             cmds: vec![Command::of(OpCode::NoOp, &[], &[])],
-            final_deps: vec![(1, 1).into(), (2, 0).into(), (3, 0).into()],
+            final_deps: Some([(1, 1), (2, 0), (3, 0)].into()),
             ..Default::default()
         },
         Instance {
             instance_id: Some((3, 1).into()),
             cmds: vec![Command::of(OpCode::Set, &[1], &[11])],
-            final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 0).into()],
+            final_deps: Some([(1, 1), (2, 1), (3, 0)].into()),
             ..Default::default()
         },
     ];
@@ -303,7 +303,7 @@ fn test_replica_execute() {
         (
             vec![Instance {
                 instance_id: Some((1, 1).into()),
-                final_deps: vec![(1, 0).into(), (2, 0).into(), (3, 0).into()],
+                final_deps: Some([(1, 0), (2, 0), (3, 0)].into()),
                 committed: true,
                 ..Default::default()
             }],
@@ -325,19 +325,19 @@ fn test_replica_execute() {
             vec![
                 Instance {
                     instance_id: Some((1, 2).into()),
-                    final_deps: vec![(1, 1).into(), (2, 1).into(), (3, 1).into()],
+                    final_deps: Some([(1, 1), (2, 1), (3, 1)].into()),
                     committed: true,
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((2, 2).into()),
-                    final_deps: vec![(1, 2).into(), (2, 1).into(), (3, 1).into()],
+                    final_deps: Some([(1, 2), (2, 1), (3, 1)].into()),
                     committed: true,
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((3, 2).into()),
-                    final_deps: vec![(1, 2).into(), (2, 2).into(), (3, 1).into()],
+                    final_deps: Some([(1, 2), (2, 2), (3, 1)].into()),
                     committed: true,
                     ..Default::default()
                 },
@@ -360,19 +360,19 @@ fn test_replica_execute() {
             vec![
                 Instance {
                     instance_id: Some((1, 3).into()),
-                    final_deps: vec![(1, 2).into(), (2, 3).into(), (3, 2).into()],
+                    final_deps: Some([(1, 2), (2, 3), (3, 2)].into()),
                     committed: true,
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((2, 3).into()),
-                    final_deps: vec![(1, 3).into(), (2, 2).into(), (3, 2).into()],
+                    final_deps: Some([(1, 3), (2, 2), (3, 2)].into()),
                     committed: true,
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((3, 3).into()),
-                    final_deps: vec![(1, 3).into(), (2, 2).into(), (3, 2).into()],
+                    final_deps: Some([(1, 3), (2, 2), (3, 2)].into()),
                     committed: true,
                     ..Default::default()
                 },
@@ -386,19 +386,19 @@ fn test_replica_execute() {
             vec![
                 Instance {
                     instance_id: Some((1, 4).into()),
-                    final_deps: vec![(1, 3).into(), (2, 4).into(), (3, 4).into()],
+                    final_deps: Some([(1, 3), (2, 4), (3, 4)].into()),
                     committed: true,
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((2, 4).into()),
-                    final_deps: vec![(1, 3).into(), (2, 3).into(), (3, 4).into()],
+                    final_deps: Some([(1, 3), (2, 3), (3, 4)].into()),
                     committed: true,
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((3, 4).into()),
-                    final_deps: vec![(1, 4).into(), (2, 4).into(), (3, 3).into()],
+                    final_deps: Some([(1, 4), (2, 4), (3, 3)].into()),
                     committed: true,
                     ..Default::default()
                 },
@@ -412,13 +412,13 @@ fn test_replica_execute() {
             vec![
                 Instance {
                     instance_id: Some((2, 5).into()),
-                    final_deps: vec![(1, 5).into(), (2, 4).into(), (3, 5).into()],
+                    final_deps: Some([(1, 5), (2, 4), (3, 5)].into()),
                     committed: true,
                     ..Default::default()
                 },
                 Instance {
                     instance_id: Some((3, 5).into()),
-                    final_deps: vec![(1, 4).into(), (2, 5).into(), (3, 4).into()],
+                    final_deps: Some([(1, 4), (2, 5), (3, 4)].into()),
                     committed: true,
                     ..Default::default()
                 },

--- a/components/epaxos/src/snapshot/test_engine.rs
+++ b/components/epaxos/src/snapshot/test_engine.rs
@@ -95,7 +95,7 @@ pub fn test_get_instance_iter(
             assert_eq!(act.cmds, cmds);
             assert_eq!(act.ballot, Some(ballot));
 
-            for (idx, inst_id) in act.initial_deps.iter().enumerate() {
+            for (idx, inst_id) in act.initial_deps.unwrap().iter().enumerate() {
                 assert_eq!(*inst_id, deps[idx]);
             }
 
@@ -152,8 +152,8 @@ fn new_foo_inst(leader_id: i64) -> Instance {
     let mut inst = Instance::of(&cmds[..], ballot, &initial_deps[..]);
     // TODO move these to Instance::new_instance
     inst.instance_id = Some((leader_id, 1).into());
-    inst.deps = [iid2].to_vec();
-    inst.final_deps = [iid3].to_vec();
+    inst.deps = Some([iid2].to_vec().into());
+    inst.final_deps = Some([iid3].to_vec().into());
     inst.last_ballot = Some(ballot2);
 
     inst


### PR DESCRIPTION
# Description           <!-- summary, motivation and context -->

### refactor: use InstanceIdVec.get() in Instance.after()


### use InstanceIdVec to replace repeated InstanceID




## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**

<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
