### PR TITLE
replica::new_instance

### DIFF
--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -64,7 +64,7 @@ impl Replica {
         None
     }
 
-    pub fn execute_commands(&mut self, inst: &Instance) -> Result<Vec<ExecuteResult>, Error> {
+    pub fn execute_commands(&self, inst: &Instance) -> Result<Vec<ExecuteResult>, Error> {
         let mut rst = Vec::new();
         for cmd in inst.cmds.iter() {
             if OpCode::NoOp as i32 == cmd.op {

--- a/components/epaxos/src/replica/test_exec.rs
+++ b/components/epaxos/src/replica/test_exec.rs
@@ -1,9 +1,33 @@
 use crate::qpaxos::{Command, Instance, InstanceId};
-use crate::replica::test_replica;
+use crate::replica::ReplicaConf;
 use crate::replica::{ExecuteResult, Replica};
+use crate::snapshot::MemEngine;
+use std::sync::{Arc, Mutex};
+
+/// Create a stupid replica with some instances stored.
+fn new_foo_replica(replica_id: i64, insts: &[((i64, i64), &Instance)]) -> Replica {
+    let mut r = Replica {
+        replica_id,
+        group_replica_ids: vec![0, 1, 2],
+        peers: vec![],
+        conf: ReplicaConf {
+            ..Default::default()
+        },
+        inst_idx: 0,
+        latest_cp: (1, 1).into(),
+        storage: Arc::new(MemEngine::new().unwrap()),
+        problem_inst_ids: vec![],
+    };
+
+    for (iid, inst) in insts.iter() {
+        r.storage.set_obj((*iid).into(), inst).unwrap();
+    }
+
+    r
+}
 
 fn new_replica() -> Replica {
-    test_replica::new_foo_replica(1, &vec![])
+    new_foo_replica(1, &vec![])
 }
 
 #[allow(unused_macros)]

--- a/components/epaxos/src/snapshot/mem_engine/memdb.rs
+++ b/components/epaxos/src/snapshot/mem_engine/memdb.rs
@@ -21,7 +21,7 @@ impl Base for MemEngine {
     // TODO lock().unwrap() need to deal with poisoning
     // https://doc.rust-lang.org/std/sync/struct.Mutex.html#poisoning
 
-    fn set_kv(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
+    fn set_kv(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
         let mut bt = self._db.lock().unwrap();
         bt.insert(key, value);
         Ok(())
@@ -91,7 +91,7 @@ impl ColumnedEngine for MemEngine {
 }
 
 impl InstanceEngine for MemEngine {
-    fn next_instance_id(&mut self, rid: ReplicaID) -> Result<InstanceId, Error> {
+    fn next_instance_id(&self, rid: ReplicaID) -> Result<InstanceId, Error> {
         // TODO locking
         // TODO Need to incr max-ref and add new-instance in a single tx.
         //      Or iterator may encounter an empty instance slot.
@@ -109,7 +109,7 @@ impl InstanceEngine for MemEngine {
         Ok(max)
     }
 
-    fn set_instance(&mut self, inst: &Instance) -> Result<(), Error> {
+    fn set_instance(&self, inst: &Instance) -> Result<(), Error> {
         // TODO does not guarantee in a transaction
 
         let iid = inst.instance_id.unwrap();
@@ -140,11 +140,11 @@ impl InstanceEngine for MemEngine {
 }
 
 impl TxEngine for MemEngine {
-    fn trans_begin(&mut self) {}
-    fn trans_commit(&mut self) -> Result<(), Error> {
+    fn trans_begin(&self) {}
+    fn trans_commit(&self) -> Result<(), Error> {
         Ok(())
     }
-    fn trans_rollback(&mut self) -> Result<(), Error> {
+    fn trans_rollback(&self) -> Result<(), Error> {
         Ok(())
     }
     fn get_kv_for_update(&self, _key: &Vec<u8>) -> Result<Vec<u8>, Error> {

--- a/components/epaxos/src/snapshot/rocks_engine/engine.rs
+++ b/components/epaxos/src/snapshot/rocks_engine/engine.rs
@@ -67,7 +67,7 @@ impl RocksDBEngine {
     }
 
     /// Set a key-value pair to rocksdb.
-    fn set(&mut self, cfkv: &CfKV) -> Result<(), Error> {
+    fn set(&self, cfkv: &CfKV) -> Result<(), Error> {
         let cfh = self._make_cf_handle(cfkv.cf)?;
         Ok(self.db.put_cf(cfh, cfkv.k, cfkv.v)?)
     }
@@ -112,7 +112,7 @@ impl RocksDBEngine {
     }
 
     /// Set multi keys-values to rocksdb atomically.
-    fn _mset(&mut self, cfkvs: &Vec<CfKV>) -> Result<(), Error> {
+    fn _mset(&self, cfkvs: &Vec<CfKV>) -> Result<(), Error> {
         let wb = WriteBatch::new();
 
         for cfkv in cfkvs {
@@ -161,7 +161,7 @@ impl RocksDBEngine {
 }
 
 impl Base for RocksDBEngine {
-    fn set_kv(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
+    fn set_kv(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
         self.set(&CfKV {
             cf: &DBColumnFamily::Default,
             k: &key,


### PR DESCRIPTION
### feat: replica: add new_instance

-   Engine does not need a `mut` ref to work. All `&mut self` are
    changed to `&self`. It is the reponsibility of the Engine to deal
    with data modification.
    In our case, RocksEngine calls underlying C-API to modify data,
    MemEngine uses a Mutex to protect the underlying BTreeMap.

-   Define a type `Storage` which is an Arc of a trait object.

-   Testing: every file use its own resource creation utilities.
    A test should better not rely on another test.
    Prefer duplication than generalization for tests.

Fix: #132

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
