### PR TITLE
fix: quorum() gives wrong result when n=2k

### DIFF
--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -353,13 +353,15 @@ impl Replica {
     fn _bcast_commit(&mut self, inst: &Instance) {}
 
     pub fn quorum(&self) -> i32 {
-        let f = self.group_replica_ids.len() as i32 / 2;
-        f + 1
+        let n = self.group_replica_ids.len() as i32;
+        n / 2 + 1
     }
 
     pub fn fast_quorum(&self) -> i32 {
-        let f = self.group_replica_ids.len() as i32 / 2;
-        f + (f + 1) / 2
+        let n = self.group_replica_ids.len() as i32;
+        let q = n / 2 + 1;
+        let f = (n - 1) / 2;
+        f + q / 2
     }
 }
 

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -4,6 +4,7 @@ use crate::replica::*;
 use crate::snapshot::Error as SnapError;
 use crate::snapshot::MemEngine;
 use crate::snapshot::Storage;
+use pretty_assertions::assert_eq;
 use std::sync::Arc;
 
 /// Create an instance with command "set x=y".
@@ -159,6 +160,34 @@ fn test_new_instance() {
         r2.new_instance(cmds.clone()).unwrap(),
         init_inst!((rid2, 1), [("Set", "x", "1")], [(rid1, 0), (rid2, 0)])
     );
+}
+
+#[test]
+fn test_quorums() {
+    let cases: Vec<(i32, i32, i32)> = vec![
+        (0, 1, 0),
+        (1, 1, 0),
+        (2, 2, 1),
+        (3, 2, 2),
+        (4, 3, 2),
+        (5, 3, 3),
+        (6, 4, 4),
+        (7, 4, 5),
+        (8, 5, 5),
+        (9, 5, 6),
+    ];
+
+    for (n_replicas, q, fastq) in cases {
+        let mut r = new_foo_replica(1, new_mem_sto(), &[]);
+        r.group_replica_ids = vec![];
+
+        for i in 0..n_replicas {
+            r.group_replica_ids.push(i as ReplicaID);
+        }
+
+        assert_eq!(q, r.quorum(), "quorum n={}", n_replicas);
+        assert_eq!(fastq, r.fast_quorum(), "fast-quorum n={}", n_replicas);
+    }
 }
 
 #[test]


### PR DESCRIPTION


## Type of change       <!-- delete irrelevant options. -->

- **Bug fix**           <!-- non-breaking change which fixes an issue -->

<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
