### PR TITLE
feat: add qpaxos::quorums.rs to calculate quorum number.

### DIFF
--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -20,14 +20,20 @@ pub use q_paxos_client::*;
 pub use q_paxos_server::*;
 
 pub mod conflict;
+pub mod quorums;
+
 pub use conflict::*;
 pub use macros::*;
+pub use quorums::*;
 
 #[cfg(test)]
 mod t;
 
 #[cfg(test)]
 mod test_macros;
+
+#[cfg(test)]
+mod test_quorums;
 
 #[cfg(test)]
 mod test_command;

--- a/components/epaxos/src/qpaxos/quorums.rs
+++ b/components/epaxos/src/qpaxos/quorums.rs
@@ -1,0 +1,9 @@
+pub fn quorum(n: i32) -> i32 {
+    n / 2 + 1
+}
+
+pub fn fast_quorum(n: i32) -> i32 {
+    let q = n / 2 + 1;
+    let f = (n - 1) / 2;
+    f + q / 2
+}

--- a/components/epaxos/src/qpaxos/test_quorums.rs
+++ b/components/epaxos/src/qpaxos/test_quorums.rs
@@ -17,6 +17,11 @@ fn test_quorums() {
 
     for (n_replicas, q, fastq) in cases {
         assert_eq!(q, quorum(n_replicas), "quorum n={}", n_replicas);
-        assert_eq!(fastq, fast_quorum(n_replicas), "fast-quorum n={}", n_replicas);
+        assert_eq!(
+            fastq,
+            fast_quorum(n_replicas),
+            "fast-quorum n={}",
+            n_replicas
+        );
     }
 }

--- a/components/epaxos/src/qpaxos/test_quorums.rs
+++ b/components/epaxos/src/qpaxos/test_quorums.rs
@@ -1,0 +1,22 @@
+use super::quorums::*;
+
+#[test]
+fn test_quorums() {
+    let cases: Vec<(i32, i32, i32)> = vec![
+        (0, 1, 0),
+        (1, 1, 0),
+        (2, 2, 1),
+        (3, 2, 2),
+        (4, 3, 2),
+        (5, 3, 3),
+        (6, 4, 4),
+        (7, 4, 5),
+        (8, 5, 5),
+        (9, 5, 6),
+    ];
+
+    for (n_replicas, q, fastq) in cases {
+        assert_eq!(q, quorum(n_replicas), "quorum n={}", n_replicas);
+        assert_eq!(fastq, fast_quorum(n_replicas), "fast-quorum n={}", n_replicas);
+    }
+}

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -315,16 +315,14 @@ impl Replica {
 
     fn _bcast_commit(&self, _inst: &Instance) {}
 
+    // TODO remove these two function
+
     pub fn quorum(&self) -> i32 {
-        let n = self.group_replica_ids.len() as i32;
-        n / 2 + 1
+        quorum(self.group_replica_ids.len() as i32)
     }
 
     pub fn fast_quorum(&self) -> i32 {
-        let n = self.group_replica_ids.len() as i32;
-        let q = n / 2 + 1;
-        let f = (n - 1) / 2;
-        f + q / 2
+        fast_quorum(self.group_replica_ids.len() as i32)
     }
 }
 


### PR DESCRIPTION
Calculating quorum number should not a task of a replica.

## Type of change       <!-- delete irrelevant options. -->


- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
