### PR TITLE
feat: add qpaxos::errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: rust
 # cache: cargo
 
 rust:
-  - stable
+  # - stable
   # - beta
-  # - nightly
+  - nightly
 
 # matrix:
 #   allow_failures:

--- a/components/epaxos/src/qpaxos/errors.rs
+++ b/components/epaxos/src/qpaxos/errors.rs
@@ -1,0 +1,39 @@
+use crate::qpaxos::{InvalidRequest, QError, ReplicaID};
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum ProtocolError {
+        NoSuchReplica(rid: ReplicaID, my_rid: ReplicaID) {
+            from(ids: (ReplicaID, ReplicaID)) -> (ids.0, ids.1)
+            display("no such replica:{}, my replica_id:{}", rid, my_rid)
+        }
+
+        LackOf(field: String) {
+            display("lack of required field:{}", field)
+        }
+    }
+}
+
+impl Into<QError> for ProtocolError {
+    fn into(self) -> QError {
+        match self {
+            Self::NoSuchReplica(rid, my_rid) => QError {
+                req: Some(InvalidRequest {
+                    field: "cmn.to_replica_id".into(),
+                    problem: "NotFound".into(),
+                    ctx: format!("{}; my replica_id: {}", rid, my_rid).into(),
+                }),
+                ..Default::default()
+            },
+
+            Self::LackOf(f) => QError {
+                req: Some(InvalidRequest {
+                    field: f.clone(),
+                    problem: "LackOf".into(),
+                    ctx: "".into(),
+                }),
+                ..Default::default()
+            },
+        }
+    }
+}

--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -20,9 +20,11 @@ pub use q_paxos_client::*;
 pub use q_paxos_server::*;
 
 pub mod conflict;
+pub mod errors;
 pub mod quorums;
 
 pub use conflict::*;
+pub use errors::*;
 pub use macros::*;
 pub use quorums::*;
 
@@ -37,6 +39,9 @@ mod test_quorums;
 
 #[cfg(test)]
 mod test_command;
+
+#[cfg(test)]
+mod test_errors;
 
 #[cfg(test)]
 mod test_instance;

--- a/components/epaxos/src/qpaxos/test_errors.rs
+++ b/components/epaxos/src/qpaxos/test_errors.rs
@@ -1,0 +1,45 @@
+use crate::qpaxos::errors::ProtocolError;
+use crate::qpaxos::{InvalidRequest, QError};
+
+#[cfg(test)]
+use pretty_assertions::assert_eq;
+
+#[test]
+fn test_protocol_error() {
+    // NoSuchReplica
+    let e = ProtocolError::NoSuchReplica(1, 2);
+    assert_eq!("no such replica:1, my replica_id:2", format!("{}", e));
+
+    let e = ProtocolError::from((1, 2));
+    assert_eq!("no such replica:1, my replica_id:2", format!("{}", e));
+
+    let q: QError = e.into();
+    assert_eq!(
+        q,
+        QError {
+            req: Some(InvalidRequest {
+                field: "cmn.to_replica_id".into(),
+                problem: "NotFound".into(),
+                ctx: format!("{}; my replica_id: {}", 1, 2).into(),
+            }),
+            ..Default::default()
+        }
+    );
+
+    // LackOf
+    let e = ProtocolError::LackOf("a.b".into());
+    assert_eq!("lack of required field:a.b", format!("{}", e));
+
+    let q: QError = e.into();
+    assert_eq!(
+        q,
+        QError {
+            req: Some(InvalidRequest {
+                field: "a.b".into(),
+                problem: "LackOf".into(),
+                ctx: "".into(),
+            }),
+            ..Default::default()
+        }
+    );
+}


### PR DESCRIPTION
-   Move protocol error into qpaxos::errors::ProtocolError:
    NoSuchReplica, LackOf.

-   Define `Into<QError>` to replace to_qerr().

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Test changes**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
