### PR TITLE
Replica error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ rust:
 #     - rust: nightly
 
 script:
-  - rustup component add rustfmt
     # concurrent test causes port conflict
   - cargo test --verbose --all -- --test-threads=1
 

--- a/components/epaxos/build.rs
+++ b/components/epaxos/build.rs
@@ -3,7 +3,12 @@ extern crate tonic_build;
 fn main() {
     // tonic_build::compile_protos("../proto/helloworld.proto").unwrap();
 
+    // On travis `rustup component add rustfmt` report an error that can not find rustfmt on a
+    // nightly channel.
+    // Thus we disable formatting generated code on travis.
+    let fmt = option_env!("TRAVIS_RUST_VERSION").is_none();
     tonic_build::prost::configure()
+        .format(fmt)
         .build_client(true)
         .build_server(true)
         .type_attribute("OpCode", "#[derive(enum_utils::FromStr)]")

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -1,6 +1,5 @@
 use crate::qpaxos::*;
 use crate::replica::AcceptStatus;
-use crate::replica::Error;
 use crate::replica::*;
 use crate::snapshot::MemEngine;
 use crate::snapshot::Storage;

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -530,7 +530,7 @@ fn test_handle_accept_reply() {
         // with reply err
         let mut st = AcceptStatus::new(rp.quorum());
         let mut repl = MakeReply::accept(&foo_inst);
-        repl.err = Some(Error::LackOf("test".to_string()).to_qerr());
+        repl.err = Some(ProtocolError::LackOf("test".to_string()).into());
         assert!(handle_accept_reply(&mut rp, &repl, &mut st).is_ok());
 
         _test_get_inst(

--- a/components/epaxos/src/snapshot/errors.rs
+++ b/components/epaxos/src/snapshot/errors.rs
@@ -1,3 +1,6 @@
+use crate::qpaxos::QError;
+use crate::qpaxos::StorageFailure;
+
 quick_error! {
     /// Errors occur when set/get with snapshot
     #[derive(Debug, PartialEq)]
@@ -8,5 +11,21 @@ quick_error! {
         }
 
         NotFound{}
+    }
+}
+
+impl Into<QError> for Error {
+    fn into(self) -> QError {
+        match self {
+            Self::DBError(_) => QError {
+                sto: Some(StorageFailure {}),
+                ..Default::default()
+            },
+
+            Self::NotFound {} => QError {
+                sto: Some(StorageFailure {}),
+                ..Default::default()
+            },
+        }
     }
 }


### PR DESCRIPTION
### ci: do not format proto file on travis


### refactor: clarify error definition.

```
ReplicaError  ----------------into-+-> QError
   |                               |
   + wrap --> ProtocolError --into-'
   + wrap --> SnapError(storage error)
   - -------> other replica error
```

-   travis: fix: use nightly rustfmt to make tonic-build happy.

-   ReplicaError wraps ProtocolError and Storage error.
    Then it is easier to transfer error between functions.

-   Impl conversion from errors to QError with `Into<QError>`, instead
    of to_qerr().

-   Refactor: use specific error name such ReplicaError, ProtocolError
    etc.



## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
