### PR TITLE
refactor: use one Status to track all phases: fast, accept, prepare etc.

### DIFF
--- a/components/epaxos/src/replica/status.rs
+++ b/components/epaxos/src/replica/status.rs
@@ -32,28 +32,53 @@ impl Instance {
     }
 }
 
-pub struct Status {
+/// Status tracks replication status during fast-accept, accept and commit phase.
+pub struct Status<'a> {
+    // TODO: to work with cluster membership updating, a single number quorum is not enough in future.
+    pub fast_quorum: i32,
     pub quorum: i32,
-    pub ok_count: i32,
+
+    // With a cached instance it is possible to reduce storage access during replication.
+    pub instance: &'a Instance,
+
+    /// fast_replied tracks what replica has sent back FastAcceptReply.
+    /// It is used to de-dup duplicated messages.
+    pub fast_replied: HashMap<ReplicaID, bool>,
+
+    /// fast_deps collects `deps` received in fast-accept phase.
+    /// They are stored by dependency instance leader.
+    pub fast_deps: HashMap<ReplicaID, Vec<InstanceId>>,
+
+    /// fast_committed tracks what updated dep instance is committed.
+    pub fast_committed: HashMap<InstanceId, bool>,
+
+    /// accept_replie tracks what replica has sent back AcceptReply.
+    /// It does include the leader itself, although the leader update instance status
+    /// to "accept" locally.
+    pub accept_replied: HashMap<ReplicaID, bool>,
+
+    pub accept_ok: i32,
 }
 
-impl Status {
-    pub fn new(quorum: i32) -> Self {
+impl<'a> Status<'a> {
+    pub fn new(n_replica: i32, instance: &'a Instance) -> Self {
         Self {
-            quorum,
-            ok_count: 1,
+            quorum: quorum(n_replica),
+            fast_quorum: fast_quorum(n_replica),
+            instance,
+            fast_replied: HashMap::new(),
+            fast_deps: HashMap::new(),
+            fast_committed: HashMap::new(),
+            accept_replied: HashMap::new(),
+            accept_ok: 1,
         }
     }
 
     pub fn finish(&mut self) -> bool {
-        self.ok_count += 1;
-        self.ok_count >= self.quorum
+        self.accept_ok += 1;
+        self.accept_ok >= self.quorum
     }
 }
-
-pub type FastAcceptStatus = Status;
-pub type AcceptStatus = Status;
-pub type PrepareStatus = Status;
 
 /// `get_fast_commit_dep` finds out the safe dependency by a leader for fast commit.
 ///

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::qpaxos::*;
-use crate::replica::AcceptStatus;
+use crate::replica::Status;
 use crate::replica::*;
 use crate::snapshot::MemEngine;
 use crate::snapshot::Storage;
@@ -506,7 +506,7 @@ fn test_handle_commit_request() {
 async fn _handle_accept_reply(
     ra: &Replica,
     repl: &AcceptReply,
-    st: &mut AcceptStatus,
+    st: &mut Status,
 ) -> Result<(), Error> {
     handle_accept_reply(ra, repl, st).await
 }
@@ -524,7 +524,7 @@ fn test_handle_accept_reply() {
 
     {
         // success
-        let mut st = AcceptStatus::new(quorum(n));
+        let mut st = Status::new(n, &foo_inst);
         let repl = MakeReply::accept(&foo_inst);
         assert!(_handle_accept_reply(&rp, &repl, &mut st).is_ok());
 
@@ -545,7 +545,7 @@ fn test_handle_accept_reply() {
     rp.storage.set_instance(&foo_inst).unwrap();
     {
         // with reply err
-        let mut st = AcceptStatus::new(quorum(n));
+        let mut st = Status::new(n, &foo_inst);
         let mut repl = MakeReply::accept(&foo_inst);
         repl.err = Some(ProtocolError::LackOf("test".to_string()).into());
         assert!(_handle_accept_reply(&rp, &repl, &mut st).is_ok());
@@ -567,7 +567,7 @@ fn test_handle_accept_reply() {
     rp.storage.set_instance(&foo_inst).unwrap();
     {
         // with high ballot num
-        let mut st = AcceptStatus::new(quorum(n));
+        let mut st = Status::new(n, &foo_inst);
         let mut repl = MakeReply::accept(&foo_inst);
         repl.cmn.as_mut().unwrap().last_ballot = Some((10, 2, replica_id).into());
         assert!(_handle_accept_reply(&rp, &repl, &mut st).is_ok());


### PR DESCRIPTION
-   Add all neccessary fields(fast-fields, accept-fields) to `Status`.

-   `Status` now has an reference to the `instance` it replicates for.

-   Add duplicated message check to handle_accept_reply().

-   Add safe ballot compare without using `unwrap()`.

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
