### PR TITLE
feat: mod replication impl replication algo.

### DIFF
--- a/components/epaxos/build.rs
+++ b/components/epaxos/build.rs
@@ -15,6 +15,9 @@ fn main() {
         //TODO command contains vec<u8> that can not be copied.
         // .type_attribute("Command", "#[derive(Copy)]")
         .type_attribute("InstanceId", "#[derive(Copy, Eq, Ord, PartialOrd, Hash)]")
+        .type_attribute("QError", "#[derive(Eq)]")
+        .type_attribute("StorageFailure", "#[derive(Eq)]")
+        .type_attribute("InvalidRequest", "#[derive(Eq)]")
         .type_attribute("InstanceIdVec", "#[derive(derive_more::From)]")
         .type_attribute(
             "BallotNum",

--- a/components/epaxos/src/lib.rs
+++ b/components/epaxos/src/lib.rs
@@ -11,6 +11,7 @@ pub mod conf;
 #[macro_use]
 pub mod qpaxos;
 pub mod replica;
+pub mod replication;
 pub mod snapshot;
 pub mod tokey;
 

--- a/components/epaxos/src/qpaxos/errors.rs
+++ b/components/epaxos/src/qpaxos/errors.rs
@@ -1,7 +1,7 @@
 use crate::qpaxos::{InvalidRequest, QError, ReplicaID};
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Eq, PartialEq)]
     pub enum ProtocolError {
         NoSuchReplica(rid: ReplicaID, my_rid: ReplicaID) {
             from(ids: (ReplicaID, ReplicaID)) -> (ids.0, ids.1)

--- a/components/epaxos/src/replica/errors.rs
+++ b/components/epaxos/src/replica/errors.rs
@@ -3,7 +3,7 @@ use crate::qpaxos::{QError, StorageFailure};
 use crate::snapshot::Error as SnapError;
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Eq, PartialEq)]
     pub enum Error {
         EngineError(s: SnapError) {
             from(err: SnapError) -> (err)

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -317,7 +317,9 @@ fn check_req_common(
     Ok((ballot, iid))
 }
 
-fn check_repl_common(cm: &Option<ReplyCommon>) -> Result<(BallotNum, InstanceId), ProtocolError> {
+pub fn check_repl_common(
+    cm: &Option<ReplyCommon>,
+) -> Result<(BallotNum, InstanceId), ProtocolError> {
     let cm = cm.as_ref().ok_or(ProtocolError::LackOf("cmn".into()))?;
     let ballot = cm
         .last_ballot

--- a/components/epaxos/src/replica/status.rs
+++ b/components/epaxos/src/replica/status.rs
@@ -33,6 +33,7 @@ impl Instance {
 }
 
 /// Status tracks replication status during fast-accept, accept and commit phase.
+#[derive(Debug)]
 pub struct Status<'a> {
     // TODO: to work with cluster membership updating, a single number quorum is not enough in future.
     pub fast_quorum: i32,

--- a/components/epaxos/src/replication/errors.rs
+++ b/components/epaxos/src/replication/errors.rs
@@ -1,0 +1,31 @@
+use crate::qpaxos::BallotNum;
+use crate::qpaxos::ProtocolError;
+use crate::qpaxos::QError;
+use crate::qpaxos::ReplicaID;
+
+quick_error! {
+    /// HandlerError is an error encountered when handle-xx-request or handle-xx-reply.
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum HandlerError {
+        /// A duplicated request/reply is received.
+        Dup(rid: ReplicaID) {
+            from(rid: ReplicaID) -> (rid)
+        }
+
+        /// There is an error occured on remote peer.
+        RemoteError(qerr: QError) {
+            from(qerr: QError) -> (qerr)
+        }
+
+        /// The ballot number is too small to proceed.
+        StaleBallot(stale: BallotNum, last: BallotNum) {
+            from(bb: (BallotNum, BallotNum)) -> (bb.0, bb.1)
+        }
+
+        /// A malformed protocol error.
+        Protocal(p: ProtocolError) {
+            from(p: ProtocolError) -> (p)
+        }
+
+    }
+}

--- a/components/epaxos/src/replication/hdlreply.rs
+++ b/components/epaxos/src/replication/hdlreply.rs
@@ -1,0 +1,60 @@
+use crate::qpaxos::*;
+use crate::replica::check_repl_common;
+use crate::replica::Status;
+use crate::replication::HandlerError;
+
+pub fn handle_fast_accept_reply(
+    st: &mut Status,
+    from_rid: ReplicaID,
+    repl: &FastAcceptReply,
+) -> Result<(), HandlerError> {
+    // A duplicated message is received. Just ignore.
+    if st.fast_replied.contains_key(&from_rid) {
+        return Err(HandlerError::Dup(from_rid));
+    }
+
+    st.fast_replied.insert(from_rid, true);
+
+    if let Some(ref e) = repl.err {
+        return Err(HandlerError::RemoteError(e.clone()));
+    }
+
+    // TODO check iid matches
+    let (last_ballot, iid) = check_repl_common(&repl.cmn)?;
+    let inst = st.instance;
+
+    let deps = repl
+        .deps
+        .as_ref()
+        .ok_or(ProtocolError::LackOf("deps".into()))?;
+    if repl.deps_committed.len() < deps.len() {
+        return Err(ProtocolError::Incomplete(
+            "deps_committed".into(),
+            deps.len() as i32,
+            repl.deps_committed.len() as i32,
+        )
+        .into());
+    }
+
+    if inst.ballot < Some(last_ballot) {
+        return Err(HandlerError::StaleBallot(
+            inst.ballot.or(Some((0, 0, 0).into())).unwrap(),
+            last_ballot,
+        ));
+    }
+
+    for (i, d) in deps.iter().enumerate() {
+        let rid = d.replica_id;
+        if !st.fast_deps.contains_key(&rid) {
+            st.fast_deps.insert(rid, Vec::new());
+        }
+
+        st.fast_deps.get_mut(&rid).unwrap().push(*d);
+
+        if repl.deps_committed[i] {
+            st.fast_committed.insert(*d, true);
+        }
+    }
+
+    Ok(())
+}

--- a/components/epaxos/src/replication/mod.rs
+++ b/components/epaxos/src/replication/mod.rs
@@ -1,0 +1,8 @@
+mod hdlreply;
+pub use hdlreply::*;
+
+mod errors;
+pub use errors::*;
+
+#[cfg(test)]
+mod test_hdlreply;

--- a/components/epaxos/src/replication/test_hdlreply.rs
+++ b/components/epaxos/src/replication/test_hdlreply.rs
@@ -1,0 +1,199 @@
+use crate::qpaxos::*;
+use crate::replica::*;
+use crate::replication::*;
+
+#[cfg(test)]
+use pretty_assertions::assert_eq;
+
+/// replcmn makes a ReplyCommon.
+/// Supported pattern:
+/// replcmn!(None, None)
+/// replcmn!(None, instid)
+/// replcmn!(ballot, None)
+/// replcmn!(ballot, instid)
+macro_rules! replcmn {
+    (None, None) => {
+        ReplyCommon {
+            last_ballot: None,
+            instance_id: None,
+        }
+    };
+    (None, $id:expr) => {
+        ReplyCommon {
+            last_ballot: None,
+            instance_id: Some($id.into()),
+        }
+    };
+    ($blt:expr, None) => {
+        ReplyCommon {
+            last_ballot: Some($blt.into()),
+            instance_id: None,
+        }
+    };
+    ($blt:expr, $id:expr) => {
+        ReplyCommon {
+            last_ballot: Some($blt.into()),
+            instance_id: Some($id.into()),
+        }
+    };
+}
+
+/// deps makes a Some(InstanceIdVec) or None
+/// Supported pattern:
+/// deps!(None)
+/// deps!([instid, instid...])
+macro_rules! deps {
+    (None) => {
+        None
+    };
+    ([$(($rid:expr, $idx:expr)),*]) => {
+        Some(instids![$(($rid, $idx)),*].into())
+    };
+}
+
+#[test]
+fn test_handle_fast_accept_reply_err() {
+    macro_rules! frepl {
+        () => {
+            FastAcceptReply {
+                ..Default::default()
+            }
+        };
+        (($blt:tt, $id:tt)) => {
+            FastAcceptReply {
+                cmn: Some(replcmn!($blt, $id)),
+                ..Default::default()
+            }
+        };
+        (($blt:tt, $id:tt), $deps:tt) => {
+            FastAcceptReply {
+                cmn: Some(replcmn!($blt, $id)),
+                deps: deps!($deps),
+                ..Default::default()
+            }
+        };
+        (($blt:tt, $id:tt), $deps:tt, $cmts:expr) => {
+            FastAcceptReply {
+                cmn: Some(replcmn!($blt, $id)),
+                deps: deps!($deps),
+                deps_committed: $cmts,
+                ..Default::default()
+            }
+        };
+    }
+
+    let inst = init_inst!((1, 2), [("Set", "x", "1")], [(1, 1)]);
+    let mut st = Status::new(3, &inst);
+
+    let cases: Vec<(FastAcceptReply, HandlerError)> = vec![
+        (frepl!(), ProtocolError::LackOf("cmn".into()).into()),
+        (
+            frepl!((None, None)),
+            ProtocolError::LackOf("cmn.last_ballot".into()).into(),
+        ),
+        (
+            frepl!((None, (1, 2))),
+            ProtocolError::LackOf("cmn.last_ballot".into()).into(),
+        ),
+        (
+            frepl!(((1, 2, 3), None)),
+            ProtocolError::LackOf("cmn.instance_id".into()).into(),
+        ),
+        (
+            frepl!(((1, 2, 3), (1, 2)), None),
+            ProtocolError::LackOf("deps".into()).into(),
+        ),
+        (
+            frepl!(((1, 2, 3), (1, 2)), [(1, 2), (2, 3)], vec![true]),
+            ProtocolError::Incomplete("deps_committed".into(), 2, 1).into(),
+        ),
+    ];
+
+    for (from_rid, (repl, want)) in cases.iter().enumerate() {
+        let r = handle_fast_accept_reply(&mut st, from_rid as ReplicaID, repl);
+        assert_eq!(r.err().unwrap(), *want);
+    }
+}
+
+#[test]
+fn test_handle_fast_accept_reply() {
+    macro_rules! frepl {
+        (($blt:tt, $id:tt), $deps:tt, $cmts:expr) => {
+            FastAcceptReply {
+                cmn: Some(replcmn!($blt, $id)),
+                deps: deps!($deps),
+                deps_committed: $cmts,
+                ..Default::default()
+            }
+        };
+    }
+
+    let inst = init_inst!((1, 2), [("Set", "x", "1")], [(1, 1)]);
+    let mut st = Status::new(3, &inst);
+
+    {
+        // positive reply updates the Status.
+        let repl: FastAcceptReply =
+            frepl!(((0, 0, 1), (1, 2)), [(1, 2), (2, 3)], vec![false, true]);
+        let from_rid = 5;
+
+        let r = handle_fast_accept_reply(&mut st, from_rid, &repl);
+        assert_eq!(r.unwrap(), ());
+        assert_eq!(st.fast_replied[&from_rid], true);
+        assert_eq!(st.fast_deps[&1], vec![(1, 2).into()]);
+        assert_eq!(st.fast_deps[&2], vec![(2, 3).into()]);
+        assert!(st.fast_committed[&instid!(2, 3)]);
+        assert_eq!(None, st.fast_committed.get(&instid!(1, 2)));
+    }
+    {
+        // greater ballot should be ignored
+        let repl: FastAcceptReply = frepl!(((100, 0, 1), (1, 2)), [(3, 4)], vec![true]);
+        let from_rid = 4;
+
+        let r = handle_fast_accept_reply(&mut st, from_rid, &repl);
+        assert_eq!(
+            r.err().unwrap(),
+            HandlerError::StaleBallot((0, 0, 1).into(), (100, 0, 1).into())
+        );
+        assert_eq!(
+            true,
+            st.fast_replied.contains_key(&from_rid),
+            "reply with higher ballot is still be recorded"
+        );
+        assert_eq!(false, st.fast_deps.contains_key(&3));
+        assert_eq!(false, st.fast_committed.contains_key(&instid!(3, 4)));
+    }
+    {
+        // duplicated message
+        let repl: FastAcceptReply = frepl!(((0, 0, 1), (1, 2)), [(3, 4)], vec![true]);
+        let from_rid = 4;
+
+        let r = handle_fast_accept_reply(&mut st, from_rid, &repl);
+        assert_eq!(r.err().unwrap(), HandlerError::Dup(from_rid));
+        assert_eq!(true, st.fast_replied.contains_key(&from_rid));
+        assert_eq!(false, st.fast_deps.contains_key(&3));
+        assert_eq!(false, st.fast_committed.contains_key(&instid!(3, 4)));
+    }
+
+    {
+        // reply contains `err` is ignored
+        let mut repl: FastAcceptReply = frepl!(((0, 0, 1), (1, 2)), [(3, 4)], vec![true]);
+        repl.err = Some(QError {
+            ..Default::default()
+        });
+        let from_rid = 6;
+
+        let r = handle_fast_accept_reply(&mut st, from_rid, &repl);
+        assert_eq!(
+            r.err().unwrap(),
+            HandlerError::RemoteError(repl.err.unwrap())
+        );
+        assert_eq!(
+            true,
+            st.fast_replied.contains_key(&from_rid),
+            "error reply should be recorded"
+        );
+        assert_eq!(false, st.fast_deps.contains_key(&3));
+        assert_eq!(false, st.fast_committed.contains_key(&instid!(3, 4)));
+    }
+}

--- a/components/epaxos/src/snapshot/errors.rs
+++ b/components/epaxos/src/snapshot/errors.rs
@@ -3,7 +3,7 @@ use crate::qpaxos::StorageFailure;
 
 quick_error! {
     /// Errors occur when set/get with snapshot
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum Error {
         DBError(msg: String) {
             from(msg: String) -> (msg)


### PR DESCRIPTION
## feat: mod replication impl replication algo.

-   Refactor: add Eq impl to errors.

-   Feature: define replication::HandlerError as enum of all errors
    occurs during handling requests/replies.

-   Add handle_fast_accept_reply().

fix: #176 

## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
