### PR TITLE
test: add test of Status::new()

### DIFF
--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -525,6 +525,7 @@ fn test_handle_accept_reply() {
     {
         // success
         let mut st = Status::new(n, &foo_inst);
+        st.start_accept();
         let repl = MakeReply::accept(&foo_inst);
         assert!(_handle_accept_reply(&rp, &repl, &mut st).is_ok());
 
@@ -546,6 +547,7 @@ fn test_handle_accept_reply() {
     {
         // with reply err
         let mut st = Status::new(n, &foo_inst);
+        st.start_accept();
         let mut repl = MakeReply::accept(&foo_inst);
         repl.err = Some(ProtocolError::LackOf("test".to_string()).into());
         assert!(_handle_accept_reply(&rp, &repl, &mut st).is_ok());
@@ -568,6 +570,7 @@ fn test_handle_accept_reply() {
     {
         // with high ballot num
         let mut st = Status::new(n, &foo_inst);
+        st.start_accept();
         let mut repl = MakeReply::accept(&foo_inst);
         repl.cmn.as_mut().unwrap().last_ballot = Some((10, 2, replica_id).into());
         assert!(_handle_accept_reply(&rp, &repl, &mut st).is_ok());

--- a/components/epaxos/src/replication/test_hdlreply.rs
+++ b/components/epaxos/src/replication/test_hdlreply.rs
@@ -83,7 +83,6 @@ fn test_handle_fast_accept_reply_err() {
     }
 
     let inst = init_inst!((1, 2), [("Set", "x", "1")], [(1, 1)]);
-    let mut st = Status::new(3, &inst);
 
     let cases: Vec<(FastAcceptReply, HandlerError)> = vec![
         (frepl!(), ProtocolError::LackOf("cmn".into()).into()),
@@ -109,9 +108,10 @@ fn test_handle_fast_accept_reply_err() {
         ),
     ];
 
-    for (from_rid, (repl, want)) in cases.iter().enumerate() {
-        let r = handle_fast_accept_reply(&mut st, from_rid as ReplicaID, repl);
-        assert_eq!(r.err().unwrap(), *want);
+    for (repl, want) in cases.iter() {
+        let mut st = Status::new(3, &inst);
+        let r = handle_fast_accept_reply(&mut st, 3, repl);
+        assert_eq!(r.err().unwrap(), *want, "fast-reply: {:?}", repl);
     }
 }
 
@@ -128,7 +128,7 @@ fn test_handle_fast_accept_reply() {
         };
     }
 
-    let inst = init_inst!((1, 2), [("Set", "x", "1")], [(1, 1)]);
+    let inst = init_inst!((1, 2), [("Set", "x", "1")], []);
     let mut st = Status::new(3, &inst);
 
     {


### PR DESCRIPTION
## test: add test of Status::new()

-   When Status::new(), it initiate accept_ok to 0, until
    Status::start_accept() is called.

-   Add Status::start_fast_accept() to initiate Status with initial
    deps.

-   Test Status::new()


## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**
- **Test changes**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
