### PR TITLE
refactor: conf: make node id.

### DIFF
--- a/components/epaxos/src/conf/conf.rs
+++ b/components/epaxos/src/conf/conf.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::net::SocketAddr;
+use std::net::AddrParseError;
 use std::path::PathBuf;
+use std::ops::{Deref, DerefMut};
 
 use super::errors::ConfError;
 
@@ -11,11 +13,14 @@ use serde::{Deserialize, Serialize};
 #[path = "./tests/conf_tests.rs"]
 mod tests;
 
+/// NodeID is the global identity of a service.
+/// A physical server could have several node on it.
+/// A node has one or more Replica it serves for.
 pub type NodeID = String;
 
-/// a struct to represent a cluster node, not necessary a replica
+/// Node is a struct to represent a cluster node, not necessary a replica.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct NodeInfo {
+pub struct Node {
     #[serde(default)]
     pub node_id: NodeID,
     pub api_addr: SocketAddr,
@@ -26,24 +31,48 @@ pub struct NodeInfo {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ClusterInfo {
-    pub nodes: BTreeMap<String, NodeInfo>,
+    /// The key is NodeID and should be unique globally.
+    /// And when parsing cluster conf yaml, it tries to convert the key:NodeID to replication addr.
+    /// In this case a user does not need to fill in `replication`.
+    //
+    // TODO: graceful handling replication addr in `key`: e.g. only when replication is None, or
+    // make `replication` an vector.
+    pub nodes: BTreeMap<String, Node>,
+}
+
+// let user to use c.get() just like c.nodes.get()
+impl Deref for ClusterInfo {
+    type Target = BTreeMap<String, Node>;
+    fn deref(&self) -> &Self::Target {
+        &self.nodes
+    }
+}
+
+// let user to use c.get() just like c.nodes.get()
+impl DerefMut for ClusterInfo {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.nodes
+    }
 }
 
 impl ClusterInfo {
-    pub fn new(path: &PathBuf) -> Result<ClusterInfo, ConfError> {
+    /// from_file read cluster conf yaml from a local file.
+    pub fn from_file(path: &PathBuf) -> Result<ClusterInfo, ConfError> {
         let content = fs::read_to_string(path)?;
         let mut cluster: ClusterInfo = serde_yaml::from_str(content.as_str())?;
 
-        for (_, node) in cluster.nodes.iter_mut() {
-            node.node_id = ClusterInfo::make_node_id("");
+        for (nid, node) in cluster.nodes.iter_mut() {
+            ClusterInfo::norm_node(nid, node)?;
         }
 
         return Ok(cluster);
     }
 
+    // TODO test bad node id as replication addr
     // make a node id from key, i.e. mac address
-    pub fn make_node_id(_: &str) -> NodeID {
-        // TODO: make sure the way to make node id
-        return String::from("");
+    pub fn norm_node(nid: &str, node: &mut Node) -> Result<(), AddrParseError> {
+        node.node_id = String::from(nid);
+        node.replication = nid.parse()?;
+        Ok(())
     }
 }

--- a/components/epaxos/src/conf/errors.rs
+++ b/components/epaxos/src/conf/errors.rs
@@ -1,10 +1,18 @@
+use std::net::AddrParseError;
+
 quick_error! {
     #[derive(Debug)]
     pub enum ConfError {
-        Error{s: String} {
-            from(err: std::io::Error) -> {s: format!("IO Error: {}", err)}
-            from(err: serde_yaml::Error) -> {s: format!("Yaml Error: {}", err)}
+        IOError(e: std::io::Error) {
+            from(e: std::io::Error) -> (e)
+        }
+
+        BadYaml(e: serde_yaml::Error) {
+            from(e: serde_yaml::Error) -> (e)
+        }
+
+        BadReplication(e: AddrParseError) {
+            from(e: AddrParseError) -> (e)
         }
     }
 }
-//from(err: std::io::Error) -> (format!("IO Error: {:?}", err))

--- a/components/epaxos/src/conf/tests/conf_tests.rs
+++ b/components/epaxos/src/conf/tests/conf_tests.rs
@@ -1,19 +1,19 @@
 use super::*;
 use std::fs::File;
 use std::io::Write;
-use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 #[test]
 fn test_conf_serde_yaml() {
+    // TODO test ipv6
+
     // create tmp yaml file
     let content = "
 nodes:
-    127.0.0.1:3331:
+    127.0.0.1:4441:
         api_addr: 127.0.0.1:3331
-        replication: 127.0.0.1:4441
-    192.168.0.1:3332:
+        replication: 127.0.0.1:5551
+    192.168.0.1:4442:
         api_addr: 192.168.0.1:3332
         api_uaddr: /var/run/usocket2
         replication: 192.168.0.1:4442
@@ -24,31 +24,26 @@ nodes:
     writer.write_all(content.as_bytes()).unwrap();
     writer.sync_all().unwrap();
 
-    // test `new`
-    let ci = ClusterInfo::new(&pb).unwrap();
+    let ci = ClusterInfo::from_file(&pb).unwrap();
     assert_eq!(2, ci.nodes.len());
 
-    let n1_key = "127.0.0.1:3331";
-    let n2_key = "192.168.0.1:3332";
+    {
+        // test `get`
+        let nid1 = "127.0.0.1:4441";
+        let nid2 = "192.168.0.1:4442";
 
-    // test `get`
-    let n1 = ci.nodes.get(n1_key).unwrap();
-    assert_eq!("", n1.node_id);
-    assert_eq!(SocketAddr::from_str(n1_key).unwrap(), n1.api_addr);
-    assert_eq!(
-        SocketAddr::from_str("127.0.0.1:4441").unwrap(),
-        n1.replication
-    );
-    assert_eq!(true, n1.api_uaddr.is_none());
+        let n1 = ci.get(nid1).unwrap();
+        assert_eq!(nid1, n1.node_id);
+        assert_eq!(n1.api_addr, "127.0.0.1:3331".parse().unwrap());
+        assert_eq!(n1.replication, nid1.parse().unwrap());
+        assert_eq!(true, n1.api_uaddr.is_none());
 
-    let n2 = ci.nodes.get(n2_key).unwrap();
-    assert_eq!("", n2.node_id);
-    assert_eq!(SocketAddr::from_str(n2_key).unwrap(), n2.api_addr);
-    assert_eq!(
-        SocketAddr::from_str("192.168.0.1:4442").unwrap(),
-        n2.replication
-    );
-    assert_eq!("/var/run/usocket2", n2.api_uaddr.as_ref().unwrap());
+        let n2 = ci.get(nid2).unwrap();
+        assert_eq!(nid2, n2.node_id);
+        assert_eq!(n2.api_addr, "192.168.0.1:3332".parse().unwrap());
+        assert_eq!(n2.replication, nid2.parse().unwrap());
+        assert_eq!("/var/run/usocket2", n2.api_uaddr.as_ref().unwrap());
+    }
 
     fs::remove_file(pb).unwrap();
 }


### PR DESCRIPTION
## refactor: conf: make node id.

-   node_id is set to the key of a node in clusterinfo.

-   And node id as an optional replication address.

-   Refine ConfError: from 3 error:std::io::Error when reading yaml.
    serde_yaml::Error when parsing yaml and from a malformed replication
    addr.

-   Deref ClusterInfo into ClusterInfo.nodes thus it is much easier to
    use.


## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
