### PR TITLE
feat: Cluster add replica-to-node-id mapping.

### DIFF
--- a/components/epaxos/src/conf/errors.rs
+++ b/components/epaxos/src/conf/errors.rs
@@ -1,3 +1,5 @@
+use crate::conf::NodeID;
+use crate::qpaxos::ReplicaID;
 use std::net::AddrParseError;
 
 quick_error! {
@@ -13,6 +15,20 @@ quick_error! {
 
         BadReplication(e: AddrParseError) {
             from(e: AddrParseError) -> (e)
+        }
+
+        OrphanReplica(rid: ReplicaID, nid: NodeID) {}
+    }
+}
+
+impl PartialEq<ConfError> for ConfError {
+    fn eq(&self, other: &ConfError) -> bool {
+        match (self, other) {
+            (Self::IOError(a), Self::IOError(b)) => a.kind() == b.kind(),
+            (Self::BadYaml(_), Self::BadYaml(_)) => true,
+            (Self::BadReplication(a), Self::BadReplication(b)) => a == b,
+            (Self::OrphanReplica(a, b), Self::OrphanReplica(x, y)) => a == x && b == y,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
## feat: Cluster add replica-to-node-id mapping.

-   feat: cluster conf yaml now requires an `replicas` dict field.

-   feat: `get_replica_node() -> &Node` to find what node a replica is.

-   feat: add `check_replicas` to ensure that there is no replica in
    conf is assigned to a absent node.

-   refactor: dep: use crate tempfile to make a temp file: easy to cleanup.


## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
