### PR TITLE
feat: use stucture in `groups->replica->node` structure to define a c…

### DIFF
--- a/components/epaxos/src/conf/errors.rs
+++ b/components/epaxos/src/conf/errors.rs
@@ -18,6 +18,8 @@ quick_error! {
         }
 
         OrphanReplica(rid: ReplicaID, nid: NodeID) {}
+
+        DupReplica(rid: ReplicaID) {}
     }
 }
 
@@ -28,6 +30,7 @@ impl PartialEq<ConfError> for ConfError {
             (Self::BadYaml(_), Self::BadYaml(_)) => true,
             (Self::BadReplication(a), Self::BadReplication(b)) => a == b,
             (Self::OrphanReplica(a, b), Self::OrphanReplica(x, y)) => a == x && b == y,
+            (Self::DupReplica(a), Self::DupReplica(b)) => a == b,
             _ => false,
         }
     }


### PR DESCRIPTION
### feat: use stucture in `groups->replica->node` structure to define a cluster.

A cluster with 3 replica-group may look like:

```
ClusterInfo:
nodes:
    127.0.0.1:4441:
        api_addr: 127.0.0.1:3331
        replication: 127.0.0.1:5551
    192.168.0.1:4442:
        api_addr: 192.168.0.1:3332
        replication: 192.168.0.1:4442
groups:
-   1: 192.168.0.1:4442
    2: 192.168.0.1:4442
-   3: 127.0.0.1:4441
-   4: 192.168.0.1:4442
```

The first group has 2 replicas, the 2nd and the 3rd have only 1 replia
in it.

No replica is allowed to be in two groups.
`group` has no name.

-   change: ClusterInfo.replicas is not serialized/deserialized.
    Instead, the value of it is extracted from ClusterInfo.groups.




## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
