### PR TITLE
feat: ClusterInfo need to track key-range to group mapping

### DIFF
--- a/components/epaxos/src/conf/errors.rs
+++ b/components/epaxos/src/conf/errors.rs
@@ -20,6 +20,8 @@ quick_error! {
         OrphanReplica(rid: ReplicaID, nid: NodeId) {}
 
         DupReplica(rid: ReplicaID) {}
+
+        GroupOutOfOrder(a: String, b: String) {}
     }
 }
 
@@ -31,6 +33,7 @@ impl PartialEq<ConfError> for ConfError {
             (Self::BadReplication(a), Self::BadReplication(b)) => a == b,
             (Self::OrphanReplica(a, b), Self::OrphanReplica(x, y)) => a == x && b == y,
             (Self::DupReplica(a), Self::DupReplica(b)) => a == b,
+            (Self::GroupOutOfOrder(a, b), Self::GroupOutOfOrder(x, y)) => a == x && b == y,
             _ => false,
         }
     }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -56,7 +56,11 @@ nodes:
         api_addr: 127.0.0.1:6379
         replication: 127.0.0.1:6666
 groups:
--   1: 127.0.0.1:6666
+-   range:
+    -   a
+    -   b
+    replicas:
+        1: 127.0.0.1:6666
 ";
         let mut f = tempfile::NamedTempFile::new().unwrap();
         f.write_all(cluster.as_bytes()).unwrap();


### PR DESCRIPTION


## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
