### PR TITLE
feat: replica: add get_max_instance_ids(), which would be used when i…

### DIFF
--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -126,6 +126,28 @@ impl Replica {
         Ok(inst)
     }
 
+    /// get_max_instance_ids returns the max instance-id for every specified replica.
+    /// If there is no instance at all by a replica, a `(rid, -1)` is filled.
+    pub fn get_max_instance_ids(&self, rids: &[ReplicaID]) -> Vec<InstanceId> {
+        // TODO move the max-ids into replica. it does not need to be in storage.
+        // This way, every time the server starts, a replica need to load the max ids from storage.
+
+        let mut iids = Vec::with_capacity(rids.len());
+
+        for rid in rids.iter() {
+            let start_iid = (*rid, i64::MAX).into();
+            let mut it = self.storage.get_instance_iter(start_iid, true, true);
+            let inst = it.next();
+            let max = match inst {
+                Some(v) => v.instance_id.unwrap(),
+                None => (*rid, -1).into(),
+            };
+
+            iids.push(max);
+        }
+        iids
+    }
+
     fn _handle_prepare(&self, _req: &PrepareRequest) -> Result<PrepareReply, String> {
         Err("not implemented".to_string())
     }

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -191,6 +191,17 @@ fn test_quorums() {
 }
 
 #[test]
+fn test_get_max_instance_ids() {
+    let (i12, i13, i34) = (foo_inst!((1, 2)), foo_inst!((1, 3)), foo_inst!((3, 4)));
+
+    let insts = vec![((1, 2), &i12), ((1, 3), &i13), ((3, 4), &i34)];
+
+    let r = new_foo_replica(3, new_mem_sto(), &insts);
+    let maxs = r.get_max_instance_ids(&[1, 3, 5]);
+    assert_eq!(maxs, instids![(1, 3), (3, 4), (5, -1)]);
+}
+
+#[test]
 fn test_handle_xxx_request_invalid() {
     let replica_id = 2;
     let mut replica = new_foo_replica(replica_id, new_mem_sto(), &vec![]);


### PR DESCRIPTION
### feat: replica: add get_max_instance_ids(), which would be used when initiating instance




## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
