### PR TITLE
change: Status now has an instance in it instead of a reference

### DIFF
--- a/components/epaxos/src/replica/status.rs
+++ b/components/epaxos/src/replica/status.rs
@@ -34,13 +34,13 @@ impl Instance {
 
 /// Status tracks replication status during fast-accept, accept and commit phase.
 #[derive(Debug)]
-pub struct Status<'a> {
+pub struct Status {
     // TODO: to work with cluster membership updating, a single number quorum is not enough in future.
     pub fast_quorum: i32,
     pub quorum: i32,
 
     // With a cached instance it is possible to reduce storage access during replication.
-    pub instance: &'a Instance,
+    pub instance: Instance,
 
     /// fast_replied tracks what replica has sent back FastAcceptReply.
     /// It is used to de-dup duplicated messages.
@@ -61,10 +61,10 @@ pub struct Status<'a> {
     pub accept_ok: i32,
 }
 
-impl<'a> Status<'a> {
+impl Status {
     /// new creates a Status with initial deps filled, as if it already fast-accepted from the
     /// instnace it serves.
-    pub fn new(n_replica: i32, instance: &'a Instance) -> Self {
+    pub fn new(n_replica: i32, instance: Instance) -> Self {
         let mut st = Self {
             quorum: quorum(n_replica),
             fast_quorum: fast_quorum(n_replica),

--- a/components/epaxos/src/replica/test_status.rs
+++ b/components/epaxos/src/replica/test_status.rs
@@ -29,11 +29,11 @@ fn test_status_new() {
     let iid = inst.instance_id.unwrap();
     let replica_id = iid.replica_id;
 
-    let st = Status::new(7, &inst);
+    let st = Status::new(7, inst.clone());
 
     assert_eq!(4, st.quorum);
     assert_eq!(5, st.fast_quorum);
-    assert_eq!(st.instance, &inst);
+    assert_eq!(st.instance, inst);
 
     get!(st.fast_replied, &replica_id, true);
 

--- a/components/epaxos/src/replication/hdlreply.rs
+++ b/components/epaxos/src/replication/hdlreply.rs
@@ -34,7 +34,7 @@ pub fn handle_fast_accept_reply(
 
     // TODO check iid matches
     let (last_ballot, _iid) = check_repl_common(&repl.cmn)?;
-    let inst = st.instance;
+    let inst = &st.instance;
 
     let deps = repl
         .deps
@@ -72,8 +72,8 @@ pub fn handle_fast_accept_reply(
     Ok(())
 }
 
-pub async fn handle_accept_reply<'a>(
-    st: &mut Status<'a>,
+pub async fn handle_accept_reply(
+    st: &mut Status,
     from_rid: ReplicaID,
     ra: &Replica,
     repl: &AcceptReply,

--- a/components/epaxos/src/replication/test_hdlreply.rs
+++ b/components/epaxos/src/replication/test_hdlreply.rs
@@ -113,7 +113,7 @@ fn test_handle_fast_accept_reply_err() {
     ];
 
     for (repl, want) in cases.iter() {
-        let mut st = Status::new(3, &inst);
+        let mut st = Status::new(3, inst.clone());
         let r = handle_fast_accept_reply(&mut st, 3, repl);
         assert_eq!(r.err().unwrap(), *want, "fast-reply: {:?}", repl);
     }
@@ -133,7 +133,7 @@ fn test_handle_fast_accept_reply() {
     }
 
     let inst = init_inst!((1, 2), [("Set", "x", "1")], []);
-    let mut st = Status::new(3, &inst);
+    let mut st = Status::new(3, inst.clone());
 
     {
         // positive reply updates the Status.
@@ -203,8 +203,8 @@ fn test_handle_fast_accept_reply() {
 }
 
 #[tokio::main]
-async fn _handle_accept_reply<'a>(
-    st: &mut Status<'a>,
+async fn _handle_accept_reply(
+    st: &mut Status,
     from_rid: ReplicaID,
     ra: &Replica,
     repl: &AcceptReply,
@@ -241,7 +241,7 @@ fn test_handle_accept_reply() {
 
     {
         // with high ballot num
-        let mut st = Status::new(n, &inst);
+        let mut st = Status::new(n, inst.clone());
         st.start_accept();
         let mut repl = MakeReply::accept(&inst);
         repl.cmn.as_mut().unwrap().last_ballot = Some((10, 2, replica_id).into());
@@ -253,7 +253,7 @@ fn test_handle_accept_reply() {
 
     {
         // with reply err
-        let mut st = Status::new(n, &inst);
+        let mut st = Status::new(n, inst.clone());
         st.start_accept();
         let mut repl = MakeReply::accept(&inst);
         repl.err = Some(ProtocolError::LackOf("test".to_string()).into());
@@ -265,7 +265,7 @@ fn test_handle_accept_reply() {
 
     {
         // success
-        let mut st = Status::new(n, &inst);
+        let mut st = Status::new(n, inst.clone());
         st.start_accept();
         let repl = MakeReply::accept(&inst);
         let r = _handle_accept_reply(&mut st, 0, &rp, &repl);


### PR DESCRIPTION
There is an issue of rust: a fake modify-a-borrowed problem:

```rust
struct Inst { a: i32, }
struct St<'a> { inst: &'a Inst, }
fn borrow_it(s: &mut St) { }

fn main() {
    let mut i = Inst{a:3};
    let mut s = St{ inst: &i, };
    i.a = 5;
    borrow_it(&mut s);
}
```

```
error[E0506]: cannot assign to `i.a` because it is borrowed
  --> refmut.rs:16:5
   |
14 |         inst: &i,
   |               -- borrow of `i.a` occurs here
15 |     };
16 |     i.a = 5;
   |     ^^^^^^^ assignment to borrowed `i.a` occurs here
17 |     borrow_it(&mut s);
   |               ------ borrow later used here

error: aborting due to previous error
```

## Type of change       <!-- delete irrelevant options. -->

- **Bug fix**           <!-- non-breaking change which fixes an issue -->
- **New feature**       <!-- non-breaking change which adds functionality -->
- **Breaking change**   <!-- fix or feature that would cause existing functionality to not work as expected -->
- **Refactoring**
- **Document changes**
- **Test changes**


<!-- delete this line if it is a bug-fix PR
## How to reproduce it

- Env: x86-64, CentOS-7.4, kernel-3.10.0, GO-1.10.1, etc.

- Step-1:
- Step-2:


## The solution (to fix a bug, implement a new feature etc.)

<!-- end of bug-fix desc -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
