### PR TITLE
feat: server: add clusterconf to specify a cluster it serves for.

### DIFF
--- a/components/epaxos/src/snapshot/traits/traits.rs
+++ b/components/epaxos/src/snapshot/traits/traits.rs
@@ -1,5 +1,7 @@
 use crate::qpaxos::{Instance, InstanceId, ReplicaID};
 use crate::tokey::ToKey;
+use std::marker::Send;
+use std::marker::Sync;
 use std::sync::Arc;
 
 // required by encode/decode
@@ -57,7 +59,7 @@ pub trait Base {
 }
 
 pub type Storage =
-    Arc<dyn InstanceEngine<ColumnId = ReplicaID, ObjId = InstanceId, Obj = Instance>>;
+    Arc<dyn InstanceEngine<ColumnId = ReplicaID, ObjId = InstanceId, Obj = Instance> + Sync + Send>;
 
 /// InstanceEngine offer functions to operate snapshot instances
 pub trait InstanceEngine: TxEngine + ColumnedEngine {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -58,7 +58,7 @@ nodes:
 groups:
 -   range:
     -   a
-    -   b
+    -   z
     replicas:
         1: 127.0.0.1:6666
 ";


### PR DESCRIPTION
### feat: server: add clusterconf to specify a cluster it serves for.

-   feat: CeleServer as server level error type.
    TODO: take a better name for it.

-   feat: Server should be able to be cloned and shared across
    coroutines. Thus core data is put into a Arc<ServerData> struct.

-   feat: Server::new() takes a parameter Storage.

-   feat: Server initialize cluster info, replcias etc.

-   refactor: extract protocol impl out of server. Adds RedisApi
    struct.


### test: set key range to [a, z] for test cluster


### feat: Storage need to be marked with Send and Sync in order to share between threads




## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
