### PR TITLE
mem and rocks use same public trait, kv/instance/ref use diff cf

### DIFF
--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -87,6 +87,9 @@ impl Replica {
         new_inst.executed = true;
         self.storage.set_instance(&new_inst)?;
 
+        let iid = inst.instance_id.unwrap();
+        self.storage.set_ref("exec", iid.replica_id, iid)?;
+
         Ok(rst)
     }
 

--- a/components/epaxos/src/snapshot/mem_engine/memdb.rs
+++ b/components/epaxos/src/snapshot/mem_engine/memdb.rs
@@ -1,17 +1,13 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Bound::Included;
 use std::ops::Bound::Unbounded;
 use std::sync::Mutex;
 
-use super::super::*;
-use super::MemEngine;
-
-use crate::qpaxos::*;
-use crate::snapshot::Command;
+use crate::snapshot::*;
 
 impl MemEngine {
     pub fn new() -> Result<MemEngine, Error> {
-        let db = BTreeMap::new();
+        let db = HashMap::new();
         Ok(MemEngine {
             _db: Mutex::new(db),
         })
@@ -22,25 +18,29 @@ impl Base for MemEngine {
     // TODO lock().unwrap() need to deal with poisoning
     // https://doc.rust-lang.org/std/sync/struct.Mutex.html#poisoning
 
-    fn set_kv(&self, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), Error> {
+    fn set(&self, cf: DBColumnFamily, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), Error> {
         let mut bt = self._db.lock().unwrap();
+        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
         bt.insert(key.clone(), value.clone());
         Ok(())
     }
 
-    fn get_kv(&self, key: &Vec<u8>) -> Result<Option<Vec<u8>>, Error> {
-        let bt = self._db.lock().unwrap();
+    fn get(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<Option<Vec<u8>>, Error> {
+        let mut bt = self._db.lock().unwrap();
+        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
         Ok(bt.get(key).map(|x| x.clone()))
     }
 
-    fn delete_kv(&self, key: &Vec<u8>) -> Result<(), Error> {
+    fn delete(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<(), Error> {
         let mut bt = self._db.lock().unwrap();
+        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
         bt.remove(key);
         Ok(())
     }
 
-    fn next_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
-        let bt = self._db.lock().unwrap();
+    fn next(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+        let mut bt = self._db.lock().unwrap();
+        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
 
         for (k, v) in bt.range(key.to_vec()..) {
             if include == false && key == k {
@@ -53,8 +53,9 @@ impl Base for MemEngine {
         None
     }
 
-    fn prev_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
-        let bt = self._db.lock().unwrap();
+    fn prev(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+        let mut bt = self._db.lock().unwrap();
+        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
 
         for (k, v) in bt.range((Unbounded, Included(key.to_vec()))).rev() {
             if include == false && key == k {
@@ -67,25 +68,16 @@ impl Base for MemEngine {
         None
     }
 
-    fn get_iter(&self, key: Vec<u8>, include: bool, reverse: bool) -> BaseIter {
-        BaseIter {
-            cursor: key,
-            include,
-            engine: self,
-            reverse,
-        }
-    }
-
     // TODO now just execute these commands in order
     fn write_batch(&self, cmds: &Vec<Command>) -> Result<(), Error> {
         for cmd in cmds {
             match cmd {
                 Command::Get(_, _) => panic!("write batch don't support Get command"),
-                Command::Set(_, k, v) => {
-                    self.set_kv(k, v).unwrap();
+                Command::Set(cf, k, v) => {
+                    self.set(*cf, k, v).unwrap();
                 }
-                Command::Delete(_, k) => {
-                    self.delete_kv(k).unwrap();
+                Command::Delete(cf, k) => {
+                    self.delete(*cf, k).unwrap();
                 }
             }
         }
@@ -94,72 +86,15 @@ impl Base for MemEngine {
     }
 }
 
-impl ObjectEngine for MemEngine {
-    type ObjId = InstanceId;
-    type Obj = Instance;
-}
-
-impl ColumnedEngine for MemEngine {
-    type ColumnId = ReplicaID;
-    fn make_ref_key(&self, typ: &str, col_id: Self::ColumnId) -> Vec<u8> {
-        match typ {
-            "max" => format!("/status/max_instance_id/{:016x}", col_id).into_bytes(),
-            "exec" => format!("/status/max_exec_instance_id/{:016x}", col_id).into_bytes(),
-            _ => panic!("unknown type ref"),
-        }
-    }
-}
-
-impl InstanceEngine for MemEngine {
-    fn next_instance_id(&self, rid: ReplicaID) -> Result<InstanceId, Error> {
-        // TODO locking
-        // TODO Need to incr max-ref and add new-instance in a single tx.
-        //      Or iterator may encounter an empty instance slot.
-        let max = self.get_ref("max", rid)?;
-        let mut max = max.unwrap_or((rid, -1).into());
-        max.idx += 1;
-        self.set_ref("max", rid, max)?;
-        Ok(max)
-    }
-
-    fn set_instance(&self, inst: &Instance) -> Result<(), Error> {
-        // TODO does not guarantee in a transaction
-
-        let iid = inst.instance_id.unwrap();
-
-        self.set_obj(iid, &inst).unwrap();
-
-        let lowest = InstanceId::from((iid.replica_id, -1));
-
-        if inst.executed {
-            self.set_ref_if("exec", iid.replica_id, iid, lowest, |x| x < iid)?;
-        }
-
-        Ok(())
-    }
-    /// get an instance with instance id
-    fn get_instance(&self, iid: InstanceId) -> Result<Option<Instance>, Error> {
-        self.get_obj(iid)
-    }
-
-    fn get_instance_iter(&self, iid: InstanceId, include: bool, reverse: bool) -> InstanceIter {
-        InstanceIter {
-            curr_inst_id: iid,
-            include,
-            engine: self,
-            reverse,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn test_base() {
-        let mut engine = MemEngine::new().unwrap();
-        test_base_trait(&mut engine);
+        let engine = Arc::new(MemEngine::new().unwrap());
+        test_base_trait(engine);
     }
 
     #[test]
@@ -186,8 +121,8 @@ mod tests {
         }
 
         {
-            let mut engine = MemEngine::new().unwrap();
-            test_get_instance_iter(&mut engine);
+            let engine = Arc::new(MemEngine::new().unwrap());
+            test_get_instance_iter(engine);
         }
     }
 }

--- a/components/epaxos/src/snapshot/mem_engine/mod.rs
+++ b/components/epaxos/src/snapshot/mem_engine/mod.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 mod memdb;
 pub use memdb::*;
 
-pub type MemBT = BTreeMap<Vec<u8>, Vec<u8>>;
+pub type MemBT = HashMap<&'static str, BTreeMap<Vec<u8>, Vec<u8>>>;
 
 /// MemEngine is a in-memory storage for testing or non-persistent environment.
 ///

--- a/components/epaxos/src/snapshot/rocks_engine/mod.rs
+++ b/components/epaxos/src/snapshot/rocks_engine/mod.rs
@@ -1,4 +1,4 @@
-use super::{Base, BaseIter, Error};
+use super::{Base, Error};
 use rocksdb::DB;
 
 mod rocks;
@@ -12,37 +12,4 @@ mod test_engine;
 
 pub struct RocksDBEngine {
     db: DB,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum DBColumnFamily {
-    Default,
-    Instance,
-    Status,
-}
-
-impl DBColumnFamily {
-    fn all() -> Vec<DBColumnFamily> {
-        vec![
-            DBColumnFamily::Default,
-            DBColumnFamily::Instance,
-            DBColumnFamily::Status,
-        ]
-    }
-}
-
-impl From<&DBColumnFamily> for &str {
-    fn from(cf: &DBColumnFamily) -> Self {
-        match cf {
-            DBColumnFamily::Default => return "default",
-            DBColumnFamily::Instance => return "instance",
-            DBColumnFamily::Status => return "status",
-        }
-    }
-}
-
-impl From<DBColumnFamily> for &str {
-    fn from(cf: DBColumnFamily) -> Self {
-        (&cf).into()
-    }
 }

--- a/components/epaxos/src/snapshot/rocks_engine/test_engine.rs
+++ b/components/epaxos/src/snapshot/rocks_engine/test_engine.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use tempfile::Builder;
 
 use super::super::RocksDBEngine;
@@ -5,13 +6,12 @@ use crate::snapshot::test_engine::*;
 
 #[test]
 fn test_base() {
-    let mut eng = new_rocks_engine();
-    test_base_trait(&mut eng);
+    test_base_trait(new_rocks_engine());
 }
 
-fn new_rocks_engine() -> RocksDBEngine {
+fn new_rocks_engine() -> Arc<RocksDBEngine> {
     let tmp_root = Builder::new().tempdir().unwrap();
     let db_path = format!("{}/test", tmp_root.path().display());
 
-    return RocksDBEngine::new(&db_path).unwrap();
+    Arc::new(RocksDBEngine::new(&db_path).unwrap())
 }

--- a/components/epaxos/src/snapshot/traits/traits.rs
+++ b/components/epaxos/src/snapshot/traits/traits.rs
@@ -1,119 +1,94 @@
 use crate::qpaxos::{Instance, InstanceId, ReplicaID};
-use crate::snapshot::Command;
 use crate::tokey::ToKey;
-use std::marker::Send;
-use std::marker::Sync;
 use std::sync::Arc;
 
 // required by encode/decode
 use prost::Message;
 
+use super::super::BaseIter;
 use super::super::Error;
 use super::super::InstanceIter;
 
-pub struct BaseIter<'a> {
-    pub cursor: Vec<u8>,
-    pub include: bool,
-    pub engine: &'a dyn Base,
-    pub reverse: bool,
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum DBColumnFamily {
+    Default,
+    Instance,
+    Status,
 }
 
-impl<'a> Iterator for BaseIter<'a> {
-    type Item = (Vec<u8>, Vec<u8>);
+impl DBColumnFamily {
+    pub fn all() -> Vec<DBColumnFamily> {
+        vec![
+            DBColumnFamily::Default,
+            DBColumnFamily::Instance,
+            DBColumnFamily::Status,
+        ]
+    }
+}
 
-    // TODO add unittest.
-    fn next(&mut self) -> Option<Self::Item> {
-        let r = if self.reverse {
-            self.engine.prev_kv(&self.cursor, self.include)
-        } else {
-            self.engine.next_kv(&self.cursor, self.include)
-        };
-
-        self.include = false;
-        match r {
-            Some(kv) => {
-                self.cursor = kv.0.clone();
-                Some(kv)
-            }
-            None => None,
+impl From<&DBColumnFamily> for &str {
+    fn from(cf: &DBColumnFamily) -> Self {
+        match cf {
+            DBColumnFamily::Default => return "default",
+            DBColumnFamily::Instance => return "instance",
+            DBColumnFamily::Status => return "status",
         }
     }
+}
+
+impl From<DBColumnFamily> for &str {
+    fn from(cf: DBColumnFamily) -> Self {
+        (&cf).into()
+    }
+}
+
+pub enum Command<'a> {
+    Get(DBColumnFamily, &'a Vec<u8>),
+    Set(DBColumnFamily, &'a Vec<u8>, &'a Vec<u8>),
+    Delete(DBColumnFamily, &'a Vec<u8>),
 }
 
 /// Base offer basic key-value access
 pub trait Base {
     /// set a new key-value
-    fn set_kv(&self, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), Error>;
+    fn set(&self, cf: DBColumnFamily, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), Error>;
 
     /// get an existing value with key
-    fn get_kv(&self, key: &Vec<u8>) -> Result<Option<Vec<u8>>, Error>;
+    fn get(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<Option<Vec<u8>>, Error>;
 
     /// delete a key
-    fn delete_kv(&self, key: &Vec<u8>) -> Result<(), Error>;
+    fn delete(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<(), Error>;
 
     /// next_kv returns a key-value pair greater than the given one(include=false),
     /// or greater or equal the given one(include=true)
-    fn next_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
+    fn next(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
 
     /// prev_kv returns a key-value pair smaller than the given one(include=false),
     /// or smaller or equal the given one(include=true)
-    fn prev_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
-
-    fn get_iter(&self, key: Vec<u8>, include: bool, reverse: bool) -> BaseIter;
+    fn prev(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
 
     fn write_batch(&self, cmds: &Vec<Command>) -> Result<(), Error>;
 }
 
-pub type Storage =
-    Arc<dyn InstanceEngine<ColumnId = ReplicaID, ObjId = InstanceId, Obj = Instance> + Sync + Send>;
-
-/// InstanceEngine offer functions to operate snapshot instances
-pub trait InstanceEngine: ColumnedEngine {
-    /// Find next available instance id and increase max-instance-id ref.
-    fn next_instance_id(&self, rid: ReplicaID) -> Result<InstanceId, Error>;
-
-    /// set an instance
-    fn set_instance(&self, inst: &Instance) -> Result<(), Error>;
-
-    /// get an instance with instance id
-    fn get_instance(&self, iid: InstanceId) -> Result<Option<Instance>, Error>;
-
-    /// get an iterator to scan all instances with a leader replica id
-    fn get_instance_iter(&self, iid: InstanceId, include: bool, reverse: bool) -> InstanceIter;
-}
-
-/// ObjectEngine wraps bytes based storage engine into an object based engine.
-/// Structured object can be stored and retreived with similar APIs.
-/// An object is serialized into bytes with protobuf engine prost.
-///
-/// TODO example
-pub trait ObjectEngine: Base {
-    /// ObjId defines the type of object id.
-    /// It must be able to convert to a key in order to store an object.
-    /// Alsot it needs to be serialized as Message in order to be stored as an object too.
-    type ObjId: ToKey + Message + std::default::Default;
-
-    /// Obj defines the type of an object.
-    type Obj: Message + std::default::Default;
-
-    fn set_obj(&self, objid: Self::ObjId, obj: &Self::Obj) -> Result<(), Error> {
-        let key = objid.to_key();
-        let mut value = vec![];
-        obj.encode(&mut value)?;
-
-        self.set_kv(&key, &value)
+pub trait KV: Base {
+    fn set_kv(&self, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), Error> {
+        self.set(DBColumnFamily::Default, key, value)
     }
 
-    fn get_obj(&self, objid: Self::ObjId) -> Result<Option<Self::Obj>, Error> {
-        let key = objid.to_key();
-        let vbs = self.get_kv(&key)?;
+    fn get_kv(&self, key: &Vec<u8>) -> Result<Option<Vec<u8>>, Error> {
+        self.get(DBColumnFamily::Default, key)
+    }
 
-        let r = match vbs {
-            Some(v) => Self::Obj::decode(v.as_slice())?,
-            None => return Ok(None),
-        };
+    fn delete_kv(&self, key: &Vec<u8>) -> Result<(), Error> {
+        self.delete(DBColumnFamily::Default, key)
+    }
 
-        Ok(Some(r))
+    fn next_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.next(DBColumnFamily::Default, key, include)
+    }
+
+    fn prev_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.prev(DBColumnFamily::Default, key, include)
     }
 }
 
@@ -122,36 +97,37 @@ pub trait ObjectEngine: Base {
 /// it introduces ColumnId to classify objects.
 /// And also it provides APIs to track objects in different columns.
 ///
-/// set_ref(type, col_id, obj_id) to store a column reference of `type` to be `obj_id`.
+/// set_ref(type, ReplicaID, InstanceId) to store InstanceId of `type` in ReplicaID.
 ///
-/// E.g.: `set_ref("max", 1, (1, 2))` to set the "max" object in column 1 to be object with object-id
-/// (1, 2)
-///
-/// A User should implement make_ref_key() to make reference keys.
-pub trait ColumnedEngine: ObjectEngine {
-    type ColumnId: Copy;
-
-    fn make_ref_key(&self, typ: &str, col_id: Self::ColumnId) -> Vec<u8>;
-
-    fn set_ref(&self, typ: &str, col_id: Self::ColumnId, objid: Self::ObjId) -> Result<(), Error> {
-        let key = self.make_ref_key(typ, col_id);
-
-        let mut value = vec![];
-        objid.encode(&mut value)?;
-
-        self.set_kv(&key, &value)
+/// E.g.: `set_ref("max", 1, (1, 2).into())` to set the "max" InstanceId of Replica 1.
+pub trait ColumnedEngine: Base {
+    fn make_ref_key(&self, typ: &str, rid: ReplicaID) -> Vec<u8> {
+        match typ {
+            "max" => format!("/status/max_instance_id/{:016x}", rid).into_bytes(),
+            "exec" => format!("/status/max_exec_instance_id/{:016x}", rid).into_bytes(),
+            _ => panic!("unknown type ref"),
+        }
     }
 
-    fn get_ref(&self, typ: &str, col_id: Self::ColumnId) -> Result<Option<Self::ObjId>, Error> {
-        let key = self.make_ref_key(typ, col_id);
-        let val = self.get_kv(&key)?;
+    fn set_ref(&self, typ: &str, rid: ReplicaID, iid: InstanceId) -> Result<(), Error> {
+        let key = self.make_ref_key(typ, rid);
+
+        let mut value = vec![];
+        iid.encode(&mut value)?;
+
+        self.set(DBColumnFamily::Status, &key, &value)
+    }
+
+    fn get_ref(&self, typ: &str, rid: ReplicaID) -> Result<Option<InstanceId>, Error> {
+        let key = self.make_ref_key(typ, rid);
+        let val = self.get(DBColumnFamily::Status, &key)?;
 
         let val = match val {
             Some(v) => v,
             None => return Ok(None),
         };
 
-        Ok(Some(Self::ObjId::decode(val.as_slice())?))
+        Ok(Some(InstanceId::decode(val.as_slice())?))
     }
 
     /// set_ref_if set ref if the current value satisifies specified condition.
@@ -161,29 +137,112 @@ pub trait ColumnedEngine: ObjectEngine {
     /// # Arguments:
     ///
     /// `typ`: ref type.
-    /// `col_id`: column id of type Self::ColumnId.
-    /// `objid`: object id of type Self::ObjId.
+    /// `rid`: column id of type InstanceId.
+    /// `iid`: object id of type InstanceId.
     /// `default`: the default value to feed to `cond` if ref is not found.
-    /// `cond`: a lambda takes one argument of type Self::ObjId.
+    /// `cond`: a lambda takes one argument of type InstanceId.
     fn set_ref_if<P>(
         &self,
         typ: &str,
-        col_id: Self::ColumnId,
-        objid: Self::ObjId,
-        default: Self::ObjId,
+        rid: ReplicaID,
+        iid: InstanceId,
+        default: InstanceId,
         cond: P,
     ) -> Result<(), Error>
     where
         Self: Sized,
-        P: Fn(Self::ObjId) -> bool,
+        P: Fn(InstanceId) -> bool,
     {
-        let r0 = self.get_ref(typ, col_id)?;
+        let r0 = self.get_ref(typ, rid)?;
         let r0 = r0.unwrap_or(default);
 
         if cond(r0) {
-            self.set_ref(typ, col_id, objid)
+            self.set_ref(typ, rid, iid)
         } else {
             Ok(())
         }
     }
 }
+
+pub trait Iter: Base {
+    fn get_iter(
+        &self,
+        cursor: Vec<u8>,
+        include: bool,
+        reverse: bool,
+        cf: DBColumnFamily,
+    ) -> BaseIter;
+
+    fn get_instance_iter(&self, iid: InstanceId, include: bool, reverse: bool) -> InstanceIter;
+}
+
+/// InstanceEngine offer functions to operate snapshot instances
+pub trait InstanceEngine: ColumnedEngine + KV + Iter + Send + Sync {
+    /// Find next available instance id and increase max-instance-id ref.
+    fn next_instance_id(&self, rid: ReplicaID) -> Result<InstanceId, Error> {
+        // TODO locking TODO Need to incr max-ref and add new-instance in a single tx.
+        //      Or iterator may encounter an empty instance slot.
+        let max = self.get_ref("max", rid)?;
+        let mut max = max.unwrap_or((rid, -1).into());
+        max.idx += 1;
+        self.set_ref("max", rid, max)?;
+        Ok(max)
+    }
+
+    /// set an instance
+    fn set_instance(&self, inst: &Instance) -> Result<(), Error> {
+        // TODO does not guarantee in a transaction
+        let iid = inst.instance_id.unwrap().to_key();
+        let mut value = vec![];
+        inst.encode(&mut value)?;
+
+        self.set(DBColumnFamily::Instance, &iid, &value)
+    }
+
+    /// get an instance with instance id
+    fn get_instance(&self, iid: InstanceId) -> Result<Option<Instance>, Error> {
+        let key = iid.to_key();
+        let vbs = self.get(DBColumnFamily::Instance, &key)?;
+        let r = match vbs {
+            Some(v) => Instance::decode(v.as_slice())?,
+            None => return Ok(None),
+        };
+
+        Ok(Some(r))
+    }
+}
+
+impl<T> KV for T where T: Base + Send + Sync {}
+impl<T> ColumnedEngine for T where T: Base + Send + Sync {}
+impl<T> InstanceEngine for T where T: Base + Send + Sync {}
+
+impl<T> Iter for T
+where
+    T: Base + Send + Sync,
+{
+    fn get_iter(
+        &self,
+        cursor: Vec<u8>,
+        include: bool,
+        reverse: bool,
+        cf: DBColumnFamily,
+    ) -> BaseIter {
+        BaseIter {
+            cursor,
+            include,
+            engine: self,
+            reverse,
+            cf,
+        }
+    }
+
+    fn get_instance_iter(&self, iid: InstanceId, include: bool, reverse: bool) -> InstanceIter {
+        InstanceIter {
+            curr_inst_id: iid,
+            include,
+            engine: self,
+            reverse,
+        }
+    }
+}
+pub type Storage = Arc<dyn InstanceEngine>;


### PR DESCRIPTION
# Description           <!-- summary, motivation and context -->

- mem和rocks仅需要实现底层base接口，其他trait 接口公用
- ref、kv、instance保存在不同的cf中，避免key相同相互覆盖
- 删除OjbectEngine trait，逻辑挪到InstanceEngine，现在来看它是多余的，只有InstanceEngine用到了它
- InstanceEngine、ColumnedEngine中所有接口参数均改为固定类型。目前来看并不需要他们支持设置参数类型
- rocks engine已经可以使用，所有接口都已完成。

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
