### PR TITLE
Server improve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tonic = "0.2"
 clap  = { version = "~2.33.0" } # command line argument parse
 epaxos = { path = "components/epaxos" }
 quick-error = { version = "1.2.2" }
+futures = "0.3.0"
 
 [dev-dependencies]
 tempfile = { version = "3.1.0" }

--- a/components/epaxos/src/service/service.rs
+++ b/components/epaxos/src/service/service.rs
@@ -6,10 +6,12 @@ use crate::qpaxos::FastAcceptReply;
 use crate::qpaxos::FastAcceptRequest;
 use crate::qpaxos::Instance;
 use crate::qpaxos::MakeReply;
-use crate::qpaxos::MakeRequest;
 use crate::qpaxos::PrepareReply;
 use crate::qpaxos::PrepareRequest;
+use crate::qpaxos::ProtocolError;
 use crate::qpaxos::QPaxos;
+use crate::qpaxos::RequestCommon;
+use crate::replica::Replica;
 use crate::ServerData;
 use std::sync::Arc;
 
@@ -25,6 +27,13 @@ impl MyQPaxos {
     pub fn new(server_data: Arc<ServerData>) -> Self {
         MyQPaxos { server_data }
     }
+    pub fn get_replica(&self, cmn: &Option<RequestCommon>) -> Result<&Replica, ProtocolError> {
+        let cmn = cmn.as_ref().ok_or(ProtocolError::LackOf("cmn".into()))?;
+        let rid = cmn.to_replica_id;
+        let r = self.server_data.local_replicas.get(&rid);
+        let r = r.ok_or(ProtocolError::NoSuchReplica(rid, 0))?;
+        Ok(r)
+    }
 }
 
 #[tonic::async_trait]
@@ -33,13 +42,21 @@ impl QPaxos for MyQPaxos {
         &self,
         request: Request<FastAcceptRequest>,
     ) -> Result<Response<FastAcceptReply>, Status> {
-        // TODO I did nothing but let the test pass happily
-        let inst = Instance {
-            ..Default::default()
+        println!("Got a request: {:?}", request);
+        let req = request.get_ref();
+        let r = self.get_replica(&req.cmn);
+        let r = match r {
+            Ok(v) => v,
+            Err(e) => {
+                let reply = FastAcceptReply {
+                    err: Some(e.into()),
+                    ..Default::default()
+                };
+                return Ok(Response::new(reply));
+            }
         };
 
-        let reply = MakeReply::fast_accept(&inst, &[]);
-        println!("Got a request: {:?}", request);
+        let reply = r.handle_fast_accept(request.get_ref());
         Ok(Response::new(reply))
     }
 
@@ -47,13 +64,20 @@ impl QPaxos for MyQPaxos {
         &self,
         request: Request<AcceptRequest>,
     ) -> Result<Response<AcceptReply>, Status> {
-        // TODO I did nothing but let the test pass happily
-        let inst = Instance {
-            ..Default::default()
-        };
-
-        let reply = MakeReply::accept(&inst);
         println!("Got a request: {:?}", request);
+        let req = request.get_ref();
+        let r = self.get_replica(&req.cmn);
+        let r = match r {
+            Ok(v) => v,
+            Err(e) => {
+                let reply = AcceptReply {
+                    err: Some(e.into()),
+                    ..Default::default()
+                };
+                return Ok(Response::new(reply));
+            }
+        };
+        let reply = r.handle_accept(request.get_ref());
         Ok(Response::new(reply))
     }
 
@@ -61,13 +85,20 @@ impl QPaxos for MyQPaxos {
         &self,
         request: Request<CommitRequest>,
     ) -> Result<Response<CommitReply>, Status> {
-        // TODO I did nothing but let the test pass happily
-        let inst = Instance {
-            ..Default::default()
-        };
-
-        let reply = MakeReply::commit(&inst);
         println!("Got a request: {:?}", request);
+        let req = request.get_ref();
+        let r = self.get_replica(&req.cmn);
+        let r = match r {
+            Ok(v) => v,
+            Err(e) => {
+                let reply = CommitReply {
+                    err: Some(e.into()),
+                    ..Default::default()
+                };
+                return Ok(Response::new(reply));
+            }
+        };
+        let reply = r.handle_commit(request.get_ref());
         Ok(Response::new(reply))
     }
 


### PR DESCRIPTION
### feat: RedisApi add singal for shutdown

### feat: QPaxos service impl add server_data thus it actually works for fast-accept, accept and commit now.

- replication impl MyQPaxos adds a new method get_replica() to get replica from request.



## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
