### PR TITLE
Refine handlers

### DIFF
--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -364,14 +364,10 @@ macro_rules! bcast_msg {
                 }
             };
 
-            rst.push(repl);
+            rst.push((p.replica_id, repl));
         }
 
-        if rst.len() > 0 {
-            return Some(rst);
-        }
-
-        return None;
+        return rst;
     }};
 }
 
@@ -379,7 +375,7 @@ pub async fn bcast_fast_accept(
     peers: &Vec<ReplicaPeer>,
     inst: &Instance,
     deps_committed: &[bool],
-) -> Option<Vec<Response<FastAcceptReply>>> {
+) -> Vec<(ReplicaID, Response<FastAcceptReply>)> {
     bcast_msg!(
         peers,
         |rid| MakeRequest::fast_accept(rid, inst, deps_committed),
@@ -390,20 +386,20 @@ pub async fn bcast_fast_accept(
 pub async fn bcast_accept(
     peers: &Vec<ReplicaPeer>,
     inst: &Instance,
-) -> Option<Vec<Response<AcceptReply>>> {
+) -> Vec<(ReplicaID, Response<AcceptReply>)> {
     bcast_msg!(peers, |rid| MakeRequest::accept(rid, inst), accept);
 }
 
 pub async fn bcast_commit(
     peers: &Vec<ReplicaPeer>,
     inst: &Instance,
-) -> Option<Vec<Response<CommitReply>>> {
+) -> Vec<(ReplicaID, Response<CommitReply>)> {
     bcast_msg!(peers, |rid| MakeRequest::commit(rid, inst), commit);
 }
 
 pub async fn bcast_prepare(
     peers: &Vec<ReplicaPeer>,
     inst: &Instance,
-) -> Option<Vec<Response<PrepareReply>>> {
+) -> Vec<(ReplicaID, Response<PrepareReply>)> {
     bcast_msg!(peers, |rid| MakeRequest::prepare(rid, inst), prepare);
 }

--- a/components/epaxos/src/replica/status.rs
+++ b/components/epaxos/src/replica/status.rs
@@ -57,8 +57,6 @@ pub struct Status {
     /// It does include the leader itself, although the leader update instance status
     /// to "accept" locally.
     pub accept_replied: HashMap<ReplicaID, bool>,
-
-    pub accept_ok: i32,
 }
 
 impl Status {
@@ -75,7 +73,6 @@ impl Status {
             fast_committed: HashMap::new(),
 
             accept_replied: HashMap::new(),
-            accept_ok: 0,
         };
 
         st.start_fast_accept();
@@ -106,13 +103,11 @@ impl Status {
     /// start_accept initiates Status to enter Accept phase.
     pub fn start_accept(&mut self) -> &mut Self {
         // local instance accepts it.
-        self.accept_ok = 1;
-        self
-    }
+        let iid = self.instance.instance_id.unwrap();
+        let rid = iid.replica_id;
+        self.accept_replied.insert(rid, true);
 
-    pub fn finish(&mut self) -> bool {
-        self.accept_ok += 1;
-        self.accept_ok >= self.quorum
+        self
     }
 
     /// get_fast_commit_deps returns a InstanceId Vec if current status satisfies fast-commit

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -500,8 +500,7 @@ async fn _bcast_fast_accept() {
     tc.start().await;
     let inst = foo_inst!((0, 1), "key_x", [(0, 0), (1, 0), (2, 0)]);
     let r = bcast_fast_accept(&tc.replicas[0].peers, &inst, &[true, true, true])
-        .await
-        .unwrap();
+        .await;
 
     println!("receive fast accept replys: {:?}", r);
     // not contain self
@@ -518,7 +517,7 @@ async fn _bcast_accept() {
     let mut tc = test_util::TestCluster::new(3);
     tc.start().await;
     let inst = foo_inst!((0, 1), "key_x", [(0, 0), (1, 0), (2, 0)]);
-    let r = bcast_accept(&tc.replicas[0].peers, &inst).await.unwrap();
+    let r = bcast_accept(&tc.replicas[0].peers, &inst).await;
 
     println!("receive accept replys: {:?}", r);
     // not contain self
@@ -535,7 +534,7 @@ async fn _bcast_commit() {
     let mut tc = test_util::TestCluster::new(3);
     tc.start().await;
     let inst = foo_inst!((0, 1), "key_x", [(0, 0), (1, 0), (2, 0)]);
-    let r = bcast_commit(&tc.replicas[0].peers, &inst).await.unwrap();
+    let r = bcast_commit(&tc.replicas[0].peers, &inst).await;
 
     println!("receive commit replys: {:?}", r);
     // not contain self
@@ -552,7 +551,7 @@ async fn _bcast_prepare() {
     let mut tc = test_util::TestCluster::new(3);
     tc.start().await;
     let inst = foo_inst!((0, 1), "key_x", [(0, 0), (1, 0), (2, 0)]);
-    let r = bcast_prepare(&tc.replicas[0].peers, &inst).await.unwrap();
+    let r = bcast_prepare(&tc.replicas[0].peers, &inst).await;
 
     println!("receive prepare replys: {:?}", r);
     // not contain self

--- a/components/epaxos/src/replica/test_status.rs
+++ b/components/epaxos/src/replica/test_status.rs
@@ -43,7 +43,6 @@ fn test_status_new() {
 
     get!(st.accept_replied, &1, None);
     get!(st.accept_replied, &2, None);
-    assert_eq!(st.accept_ok, 0);
 }
 
 #[test]

--- a/components/epaxos/src/replication/errors.rs
+++ b/components/epaxos/src/replication/errors.rs
@@ -4,6 +4,7 @@ use crate::qpaxos::QError;
 use crate::qpaxos::ReplicaID;
 use crate::replica::Error as ReplicaError;
 use storage::StorageError;
+use crate::replica::InstanceStatus;
 
 quick_error! {
     /// HandlerError is an error encountered when handle-xx-request or handle-xx-reply.
@@ -36,8 +37,8 @@ quick_error! {
         }
 
         /// A delay reply is received
-        DelayReply(msg: String) {
-            display("receive delay msg :{}", &msg)
+        DelayedReply(inst_phase: InstanceStatus, reply_phase: InstanceStatus) {
+            display("instance phase:{:?} while recv reply of phase: {:?}", inst_phase, reply_phase)
         }
     }
 }

--- a/components/epaxos/src/replication/hdlreply.rs
+++ b/components/epaxos/src/replication/hdlreply.rs
@@ -95,11 +95,7 @@ pub async fn handle_accept_reply(
     // ignore delay reply
     let status = inst.status();
     if status != InstanceStatus::Accepted {
-        return Err(HandlerError::DelayReply(format!(
-            "handle accept reply want instance status: {:?} got: {:?}",
-            InstanceStatus::Accepted,
-            status
-        )));
+        return Err(HandlerError::DelayedReply(InstanceStatus::Accepted, status));
     }
 
     if inst.ballot < Some(last_ballot) {


### PR DESCRIPTION
### refactor: handle_accept_reply should not broadcast commit. use accept_replied to track accept-replies, instead of accept_ok


### refactor: rename DelayReply to DelayedReply; formatting error should be done by the error itself, not by error emitter


### refactor: bcast_xxx() returns Vec instead of useless Option. The return value now contains replica_id to indicate what replica the response is from




## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
