### PR TITLE
Fix status

### DIFF
--- a/components/epaxos/src/replica/status.rs
+++ b/components/epaxos/src/replica/status.rs
@@ -57,6 +57,10 @@ pub struct Status {
     /// It does include the leader itself, although the leader update instance status
     /// to "accept" locally.
     pub accept_replied: HashMap<ReplicaID, bool>,
+
+    /// accept_oks tracks positive accept-replies.
+    /// AcceptReply with error, delayed, or with lower ballot does not count.
+    pub accept_oks: HashMap<ReplicaID, bool>,
 }
 
 impl Status {
@@ -73,6 +77,7 @@ impl Status {
             fast_committed: HashMap::new(),
 
             accept_replied: HashMap::new(),
+            accept_oks: HashMap::new(),
         };
 
         st.start_fast_accept();
@@ -106,6 +111,7 @@ impl Status {
         let iid = self.instance.instance_id.unwrap();
         let rid = iid.replica_id;
         self.accept_replied.insert(rid, true);
+        self.accept_oks.insert(rid, true);
 
         self
     }

--- a/components/epaxos/src/replica/status.rs
+++ b/components/epaxos/src/replica/status.rs
@@ -46,6 +46,10 @@ pub struct Status {
     /// It is used to de-dup duplicated messages.
     pub fast_replied: HashMap<ReplicaID, bool>,
 
+    /// fast_oks tracks positive fast-accept-replies.
+    /// AcceptReply with error, delayed, or with lower ballot does not count.
+    pub fast_oks: HashMap<ReplicaID, bool>,
+
     /// fast_deps collects `deps` received in fast-accept phase.
     /// They are stored by dependency instance leader.
     pub fast_deps: HashMap<ReplicaID, Vec<InstanceId>>,
@@ -73,6 +77,7 @@ impl Status {
             instance,
 
             fast_replied: HashMap::new(),
+            fast_oks: HashMap::new(),
             fast_deps: HashMap::new(),
             fast_committed: HashMap::new(),
 
@@ -91,6 +96,7 @@ impl Status {
         let rid = iid.replica_id;
 
         self.fast_replied.insert(rid, true);
+        self.fast_oks.insert(rid, true);
 
         let deps = self.instance.deps.as_ref().unwrap();
         for d in deps.iter() {

--- a/components/epaxos/src/replica/test_status.rs
+++ b/components/epaxos/src/replica/test_status.rs
@@ -36,6 +36,9 @@ fn test_status_new() {
     assert_eq!(st.instance, inst);
 
     get!(st.fast_replied, &replica_id, true);
+    get!(st.fast_oks, &replica_id, true);
+    get!(st.fast_replied, &2, None);
+    get!(st.fast_oks, &2, None);
 
     get!(st.fast_deps, &1, vec![instid!(1, 1)]);
     get!(st.fast_deps, &2, vec![instid!(2, 0)]);

--- a/components/epaxos/src/replica/test_status.rs
+++ b/components/epaxos/src/replica/test_status.rs
@@ -43,6 +43,32 @@ fn test_status_new() {
 
     get!(st.accept_replied, &1, None);
     get!(st.accept_replied, &2, None);
+
+    get!(st.accept_oks, &1, None);
+    get!(st.accept_oks, &2, None);
+}
+
+#[test]
+fn test_status_start_accept() {
+    let inst = inst!(
+        (1, 2),
+        (3, 4, _),
+        [("Set", "x", "1")],
+        [(1, 1), (2, 0)],
+        "withdeps"
+    );
+    let mut st = Status::new(7, inst.clone());
+
+    get!(st.accept_replied, &1, None);
+    get!(st.accept_oks, &1, None);
+
+    st.start_accept();
+
+    get!(st.accept_replied, &1, true);
+    get!(st.accept_replied, &2, None);
+
+    get!(st.accept_oks, &1, true);
+    get!(st.accept_oks, &2, None);
 }
 
 #[test]

--- a/components/epaxos/src/replication/hdlreply.rs
+++ b/components/epaxos/src/replication/hdlreply.rs
@@ -71,6 +71,8 @@ pub fn handle_fast_accept_reply(
         }
     }
 
+    st.fast_oks.insert(from_rid, true);
+
     Ok(())
 }
 

--- a/components/epaxos/src/replication/hdlreply.rs
+++ b/components/epaxos/src/replication/hdlreply.rs
@@ -107,5 +107,7 @@ pub async fn handle_accept_reply(
         ));
     }
 
+    st.accept_oks.insert(from_rid, true);
+
     Ok(())
 }

--- a/components/epaxos/src/replication/test_hdlreply.rs
+++ b/components/epaxos/src/replication/test_hdlreply.rs
@@ -239,6 +239,8 @@ fn test_handle_accept_reply() {
         assert!(r.is_err());
 
         assert_eq!(st.get_accept_deps(&rp.group_replica_ids), None);
+        assert_eq!(2, st.accept_replied.len());
+        assert_eq!(1, st.accept_oks.len());
     }
 
     {
@@ -252,6 +254,9 @@ fn test_handle_accept_reply() {
         assert!(r.is_err());
 
         assert_eq!(st.get_accept_deps(&rp.group_replica_ids), None);
+
+        assert_eq!(2, st.accept_replied.len());
+        assert_eq!(1, st.accept_oks.len());
     }
 
     {
@@ -264,5 +269,6 @@ fn test_handle_accept_reply() {
         assert!(r.is_ok());
 
         assert_eq!(2, st.accept_replied.len());
+        assert_eq!(2, st.accept_oks.len());
     }
 }


### PR DESCRIPTION
- fix: Status should track fast-accept-replies and positive fast-accept-replies separately.


- fix: Status should track accept-replies and positive accept-replies.


## Type of change       <!-- delete irrelevant options. -->

- **Bug fix**           <!-- non-breaking change which fixes an issue -->
- **Test changes**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
