### PR TITLE
Refactor handle accept replies

### DIFF
--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -100,6 +100,7 @@ impl Replica {
 
     /// new_instance creates a new instance with initial_deps and deps initialized and stores it in
     /// replica storage.
+    /// initial_deps and deps could contains (x, -1) if a leader has not yet propose any instance.
     pub fn new_instance(&self, cmds: &[Command]) -> Result<Instance, ReplicaError> {
         // TODO locking
         // TODO do not need to store max instance id, store it in replica and when starting, scan
@@ -114,14 +115,7 @@ impl Replica {
         let this_iid = maxs.get(rid).unwrap();
         let iid = (rid, this_iid.idx + 1).into();
 
-        let mut deps = vec![];
-        for d in maxs.iter() {
-            if d.idx >= 0 {
-                deps.push(*d);
-            }
-        }
-
-        let mut inst = Instance::of(cmds, (0, 0, rid).into(), &deps);
+        let mut inst = Instance::of(cmds, (0, 0, rid).into(), &maxs);
         inst.deps = inst.initial_deps.clone();
         inst.instance_id = Some(iid);
 

--- a/components/epaxos/src/replica/test_replica.rs
+++ b/components/epaxos/src/replica/test_replica.rs
@@ -146,7 +146,7 @@ fn test_new_instance() {
 
     // (1, 0) -> []
     let i10 = r1.new_instance(&cmds).unwrap();
-    assert_eq!(i10, init_inst!((rid1, 0), [("Set", "x", "1")], []));
+    assert_eq!(i10, init_inst!((rid1, 0), [("Set", "x", "1")], [(0, -1), (1, -1), (2, -1)]));
     assert_eq!(
         i10,
         r1.storage.get_instance((rid1, 0).into()).unwrap().unwrap()
@@ -154,7 +154,7 @@ fn test_new_instance() {
 
     // (2, 0) -> [(1, 0)]
     let i20 = r2.new_instance(&cmds).unwrap();
-    assert_eq!(i20, init_inst!((rid2, 0), [("Set", "x", "1")], [(rid1, 0)]));
+    assert_eq!(i20, init_inst!((rid2, 0), [("Set", "x", "1")], [(0, -1), (1, 0), (2, -1)]));
     assert_eq!(
         i20,
         r1.storage.get_instance((rid2, 0).into()).unwrap().unwrap()
@@ -164,7 +164,7 @@ fn test_new_instance() {
     let i21 = r2.new_instance(&cmds).unwrap();
     assert_eq!(
         i21,
-        init_inst!((rid2, 1), [("Set", "x", "1")], [(rid1, 0), (rid2, 0)])
+        init_inst!((rid2, 1), [("Set", "x", "1")], [(0, -1), (1, 0), (2, 0)])
     );
     assert_eq!(
         i21,

--- a/components/epaxos/src/replication/hdlreply.rs
+++ b/components/epaxos/src/replication/hdlreply.rs
@@ -76,7 +76,7 @@ pub fn handle_fast_accept_reply(
     Ok(())
 }
 
-pub async fn handle_accept_reply(
+pub fn handle_accept_reply(
     st: &mut Status,
     from_rid: ReplicaID,
     ra: &Replica,

--- a/components/epaxos/src/replication/test_hdlreply.rs
+++ b/components/epaxos/src/replication/test_hdlreply.rs
@@ -223,16 +223,6 @@ fn test_handle_fast_accept_reply() {
     }
 }
 
-#[tokio::main]
-async fn _handle_accept_reply(
-    st: &mut Status,
-    from_rid: ReplicaID,
-    ra: &Replica,
-    repl: &AcceptReply,
-) -> Result<(), HandlerError> {
-    handle_accept_reply(st, from_rid, ra, repl).await
-}
-
 #[test]
 fn test_handle_accept_reply() {
     let replica_id = 2;
@@ -255,7 +245,7 @@ fn test_handle_accept_reply() {
         st.start_accept();
         let mut repl = MakeReply::accept(&inst);
         repl.cmn.as_mut().unwrap().last_ballot = Some((10, 2, replica_id).into());
-        let r = _handle_accept_reply(&mut st, 0, &rp, &repl);
+        let r = handle_accept_reply(&mut st, 0, &rp, &repl);
         println!("{:?}", r);
         assert!(r.is_err());
 
@@ -270,7 +260,7 @@ fn test_handle_accept_reply() {
         st.start_accept();
         let mut repl = MakeReply::accept(&inst);
         repl.err = Some(ProtocolError::LackOf("test".to_string()).into());
-        let r = _handle_accept_reply(&mut st, 0, &rp, &repl);
+        let r = handle_accept_reply(&mut st, 0, &rp, &repl);
         println!("{:?}", r);
         assert!(r.is_err());
 
@@ -285,7 +275,7 @@ fn test_handle_accept_reply() {
         let mut st = Status::new(n, inst.clone());
         st.start_accept();
         let repl = MakeReply::accept(&inst);
-        let r = _handle_accept_reply(&mut st, 0, &rp, &repl);
+        let r = handle_accept_reply(&mut st, 0, &rp, &repl);
         println!("{:?}", r);
         assert!(r.is_ok());
 


### PR DESCRIPTION
### feat: deps use (x, -1) to represent empty dep to avoid dealing with absent dep


### refactor: handle_accept_replies does not to be async any more




## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
