### PR TITLE
Refine error

### DIFF
--- a/components/epaxos/src/replica/errors.rs
+++ b/components/epaxos/src/replica/errors.rs
@@ -1,4 +1,4 @@
-use crate::qpaxos::{ProtocolError, ReplicaId};
+use crate::qpaxos::ReplicaId;
 use crate::qpaxos::{QError, StorageFailure};
 use storage::StorageError;
 
@@ -10,10 +10,6 @@ quick_error! {
         }
 
         Existed{}
-
-        Protocol(e: ProtocolError) {
-            from(e: ProtocolError) -> (e)
-        }
 
         ReplicaNotFound(rid: ReplicaId) {
             display("replica {:?} not found in cluster", rid)
@@ -33,8 +29,6 @@ impl Into<QError> for ReplicaError {
                 sto: Some(StorageFailure {}),
                 ..Default::default()
             },
-
-            Self::Protocol(e) => e.into(),
 
             // TODO impl
             Self::ReplicaNotFound(_) => QError {

--- a/components/epaxos/src/replica/errors.rs
+++ b/components/epaxos/src/replica/errors.rs
@@ -5,14 +5,8 @@ use storage::StorageError;
 quick_error! {
     #[derive(Debug, Eq, PartialEq)]
     pub enum ReplicaError {
-        EngineError(s: StorageError) {
+        Storage(s: StorageError) {
             from(err: StorageError) -> (err)
-        }
-
-        CmdNotSupport(s: String)
-
-        SystemError(s: String) {
-            from(err: std::time::SystemTimeError) -> (format!("{:?}", err))
         }
 
         Existed{}
@@ -30,24 +24,12 @@ quick_error! {
 impl Into<QError> for ReplicaError {
     fn into(self) -> QError {
         match self {
-            Self::EngineError(_) => QError {
+            Self::Storage(_) => QError {
                 sto: Some(StorageFailure {}),
                 ..Default::default()
             },
 
             Self::Existed {} => QError {
-                sto: Some(StorageFailure {}),
-                ..Default::default()
-            },
-
-            // TODO impl
-            Self::CmdNotSupport(_) => QError {
-                sto: Some(StorageFailure {}),
-                ..Default::default()
-            },
-
-            // TODO impl
-            Self::SystemError(_) => QError {
                 sto: Some(StorageFailure {}),
                 ..Default::default()
             },

--- a/components/epaxos/src/replica/errors.rs
+++ b/components/epaxos/src/replica/errors.rs
@@ -4,7 +4,7 @@ use storage::StorageError;
 
 quick_error! {
     #[derive(Debug, Eq, PartialEq)]
-    pub enum Error {
+    pub enum ReplicaError {
         EngineError(s: StorageError) {
             from(err: StorageError) -> (err)
         }
@@ -27,7 +27,7 @@ quick_error! {
     }
 }
 
-impl Into<QError> for Error {
+impl Into<QError> for ReplicaError {
     fn into(self) -> QError {
         match self {
             Self::EngineError(_) => QError {

--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 
 use crate::qpaxos::{Instance, InstanceId, InstanceIdVec, OpCode};
-use crate::replica::{errors::Error, Replica};
+use crate::replica::{Replica, ReplicaError};
 use storage::WriteEntry;
 
 thread_local! {
@@ -69,7 +69,10 @@ impl Replica {
         None
     }
 
-    pub fn execute_commands(&self, mut insts: Vec<Instance>) -> Result<Vec<InstanceId>, Error> {
+    pub fn execute_commands(
+        &self,
+        mut insts: Vec<Instance>,
+    ) -> Result<Vec<InstanceId>, ReplicaError> {
         let mut rst = Vec::with_capacity(insts.len());
         let mut entrys: Vec<WriteEntry> = Vec::with_capacity(insts.len());
         let mut existed = HashMap::new();
@@ -129,7 +132,10 @@ impl Replica {
     /// S = {x | x ∈ S and (∃y: y → x)}
     /// so S = {b, d}
     /// sort S by instance_id and execute
-    pub fn execute_instances(&self, mut insts: Vec<Instance>) -> Result<Vec<InstanceId>, Error> {
+    pub fn execute_instances(
+        &self,
+        mut insts: Vec<Instance>,
+    ) -> Result<Vec<InstanceId>, ReplicaError> {
         let mut early = vec![false; insts.len()];
         let mut late = vec![false; insts.len()];
         let mut can_exec = Vec::with_capacity(insts.len());
@@ -187,7 +193,7 @@ impl Replica {
     pub fn get_insts_if_committed(
         &self,
         inst_ids: &Vec<InstanceId>,
-    ) -> Result<Vec<Instance>, Error> {
+    ) -> Result<Vec<Instance>, ReplicaError> {
         let mut rst = Vec::new();
         let mut recover_iids = InstanceIdVec::from([0; 0]);
 
@@ -213,7 +219,7 @@ impl Replica {
         Ok(rst)
     }
 
-    pub fn execute(&self) -> Result<Vec<InstanceId>, Error> {
+    pub fn execute(&self) -> Result<Vec<InstanceId>, ReplicaError> {
         let mut exec_up_to = InstanceIdVec::from([0; 0]);
         let mut smallest_inst_ids = InstanceIdVec::from([0; 0]);
         for rid in self.group_replica_ids.iter() {

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -3,6 +3,7 @@ use std::i64;
 use crate::conf::ClusterInfo;
 use crate::qpaxos::*;
 use crate::replica::ReplicaError;
+use crate::replication::RpcHandlerError;
 use crate::Iter;
 use crate::Storage;
 
@@ -159,13 +160,16 @@ impl Replica {
         }
     }
 
-    fn _fast_accept(&self, req: &FastAcceptRequest) -> Result<(Instance, Vec<bool>), ReplicaError> {
+    fn _fast_accept(
+        &self,
+        req: &FastAcceptRequest,
+    ) -> Result<(Instance, Vec<bool>), RpcHandlerError> {
         let (ballot, iid) = check_req_common(self.replica_id, &req.cmn)?;
 
         let mut inst = match self.storage.get_instance(iid)? {
             Some(v) => {
                 if v.ballot.is_none() || v.ballot.unwrap().num != 0 {
-                    return Err(ReplicaError::Existed {});
+                    return Err((ReplicaError::Existed {}).into());
                 }
                 v
             }
@@ -240,7 +244,7 @@ impl Replica {
         }
     }
 
-    fn _accept(&self, req: &AcceptRequest) -> Result<Instance, ReplicaError> {
+    fn _accept(&self, req: &AcceptRequest) -> Result<Instance, RpcHandlerError> {
         // TODO locking
         let (ballot, iid) = check_req_common(self.replica_id, &req.cmn)?;
 
@@ -272,7 +276,7 @@ impl Replica {
         }
     }
 
-    fn _commit(&self, req: &CommitRequest) -> Result<Instance, ReplicaError> {
+    fn _commit(&self, req: &CommitRequest) -> Result<Instance, RpcHandlerError> {
         let (ballot, iid) = check_req_common(self.replica_id, &req.cmn)?;
 
         // TODO locking

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -2,7 +2,7 @@ use std::i64;
 
 use crate::conf::ClusterInfo;
 use crate::qpaxos::*;
-use crate::replica::Error as ReplicaError;
+use crate::replica::ReplicaError;
 use crate::Iter;
 use crate::Storage;
 

--- a/components/epaxos/src/replication/errors.rs
+++ b/components/epaxos/src/replication/errors.rs
@@ -8,9 +8,9 @@ use parse::Response;
 use storage::StorageError;
 
 quick_error! {
-    /// HandlerError is an error encountered when handle-xx-request or handle-xx-reply.
+    /// RpcHandlerError is an error encountered when handle-xx-request or handle-xx-reply.
     #[derive(Debug, Eq, PartialEq)]
-    pub enum HandlerError {
+    pub enum RpcHandlerError {
         /// A duplicated request/reply is received.
         Dup(rid: ReplicaId) {
             from(rid: ReplicaId) -> (rid)
@@ -34,7 +34,10 @@ quick_error! {
         /// A malformed replica error.
         Replica(r: ReplicaError) {
             from(r: ReplicaError) -> (r)
-            from(e: StorageError) -> (e.into())
+        }
+
+        Storage(s: StorageError) {
+            from(s: StorageError) -> (s)
         }
 
         /// A delay reply is received
@@ -54,8 +57,8 @@ quick_error! {
         Replica(re: ReplicaError) {
             from(re: ReplicaError) -> (re)
         }
-        Handler(e: HandlerError) {
-            from(e: HandlerError) -> (e)
+        Handler(e: RpcHandlerError) {
+            from(e: RpcHandlerError) -> (e)
         }
         Storage(e: StorageError) {
             from(e: StorageError) -> (e)

--- a/components/epaxos/src/replication/errors.rs
+++ b/components/epaxos/src/replication/errors.rs
@@ -2,8 +2,8 @@ use crate::qpaxos::BallotNum;
 use crate::qpaxos::ProtocolError;
 use crate::qpaxos::QError;
 use crate::qpaxos::ReplicaId;
-use crate::replica::Error as ReplicaError;
 use crate::replica::InstanceStatus;
+use crate::replica::ReplicaError;
 use parse::Response;
 use storage::StorageError;
 

--- a/components/epaxos/src/replication/hdlreply.rs
+++ b/components/epaxos/src/replication/hdlreply.rs
@@ -79,7 +79,6 @@ pub fn handle_fast_accept_reply(
 pub fn handle_accept_reply(
     st: &mut Status,
     from_rid: ReplicaId,
-    ra: &Replica,
     repl: &AcceptReply,
 ) -> Result<(), HandlerError> {
     // TODO test duplicated message
@@ -93,9 +92,10 @@ pub fn handle_accept_reply(
         return Err(HandlerError::RemoteError(e.clone()));
     }
 
-    let (last_ballot, iid) = check_repl_common(&repl.cmn)?;
-    let inst = ra.get_instance(iid)?;
+    let (last_ballot, _iid) = check_repl_common(&repl.cmn)?;
+    let inst = &st.instance;
 
+    // TODO is it necessary to check status?
     // ignore delay reply
     let status = inst.status();
     if status != InstanceStatus::Accepted {

--- a/components/epaxos/src/replication/replication.rs
+++ b/components/epaxos/src/replication/replication.rs
@@ -85,7 +85,7 @@ pub async fn replicate(
     let repls = bcast_accept(&r.peers, &st.instance).await;
 
     for (from_rid, repl) in repls.iter() {
-        handle_accept_reply(&mut st, *from_rid, &r, repl.get_ref())?;
+        handle_accept_reply(&mut st, *from_rid, repl.get_ref())?;
         if st.accept_oks.len() as i32 >= st.quorum {
             // instance is safe to commit.
             return Ok(st);

--- a/components/epaxos/src/replication/test_hdlreply.rs
+++ b/components/epaxos/src/replication/test_hdlreply.rs
@@ -98,7 +98,7 @@ fn test_handle_fast_accept_reply_err() {
 
     let inst = init_inst!((1, 2), [("Set", "x", "1")], [(1, 1)]);
 
-    let cases: Vec<(FastAcceptReply, HandlerError)> = vec![
+    let cases: Vec<(FastAcceptReply, RpcHandlerError)> = vec![
         (frepl!(), ProtocolError::LackOf("cmn".into()).into()),
         (
             frepl!((None, None)),
@@ -169,7 +169,7 @@ fn test_handle_fast_accept_reply() {
         let r = handle_fast_accept_reply(&mut st, from_rid, &repl);
         assert_eq!(
             r.err().unwrap(),
-            HandlerError::StaleBallot((0, 0, 1).into(), (100, 0, 1).into())
+            RpcHandlerError::StaleBallot((0, 0, 1).into(), (100, 0, 1).into())
         );
         assert_eq!(
             true,
@@ -188,7 +188,7 @@ fn test_handle_fast_accept_reply() {
         let from_rid = 4;
 
         let r = handle_fast_accept_reply(&mut st, from_rid, &repl);
-        assert_eq!(r.err().unwrap(), HandlerError::Dup(from_rid));
+        assert_eq!(r.err().unwrap(), RpcHandlerError::Dup(from_rid));
         assert_eq!(true, st.fast_replied.contains_key(&from_rid));
 
         get!(st.fast_oks, &from_rid, None);
@@ -208,7 +208,7 @@ fn test_handle_fast_accept_reply() {
         let r = handle_fast_accept_reply(&mut st, from_rid, &repl);
         assert_eq!(
             r.err().unwrap(),
-            HandlerError::RemoteError(repl.err.unwrap())
+            RpcHandlerError::RemoteError(repl.err.unwrap())
         );
         assert_eq!(
             true,

--- a/components/epaxos/src/replication/test_hdlreply.rs
+++ b/components/epaxos/src/replication/test_hdlreply.rs
@@ -245,7 +245,7 @@ fn test_handle_accept_reply() {
         st.start_accept();
         let mut repl = MakeReply::accept(&inst);
         repl.cmn.as_mut().unwrap().last_ballot = Some((10, 2, replica_id).into());
-        let r = handle_accept_reply(&mut st, 0, &rp, &repl);
+        let r = handle_accept_reply(&mut st, 0, &repl);
         println!("{:?}", r);
         assert!(r.is_err());
 
@@ -260,7 +260,7 @@ fn test_handle_accept_reply() {
         st.start_accept();
         let mut repl = MakeReply::accept(&inst);
         repl.err = Some(ProtocolError::LackOf("test".to_string()).into());
-        let r = handle_accept_reply(&mut st, 0, &rp, &repl);
+        let r = handle_accept_reply(&mut st, 0, &repl);
         println!("{:?}", r);
         assert!(r.is_err());
 
@@ -275,7 +275,7 @@ fn test_handle_accept_reply() {
         let mut st = Status::new(n, inst.clone());
         st.start_accept();
         let repl = MakeReply::accept(&inst);
-        let r = handle_accept_reply(&mut st, 0, &rp, &repl);
+        let r = handle_accept_reply(&mut st, 0, &repl);
         println!("{:?}", r);
         assert!(r.is_ok());
 


### PR DESCRIPTION
### refactor: ReplicaError does not need to include ProtocolError


### refactor: Replica::handle_xxx_request should returns RpcHandlerError instead of ReplicaError


### refactor: ReplicaError::EngineError rename to Storage. remove unused error CmdNotSupport and SystemError


### refactor: rename replica::Error to replica::ReplicaError


### refactor: rename HandlerError to more specific name: RpcHandlerError.

- And separate sub error StorageError from ReplicaError.


### refactor: handle_accept_reply do not need to load instance from storage. use the one stored in Status



## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
