### PR TITLE
Refine errors 2

### DIFF
--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -53,6 +53,12 @@ mod test_instance;
 pub struct MakeRequest {}
 pub struct MakeReply {}
 
+#[derive(Debug, Eq, PartialEq, enum_utils::FromStr)]
+pub enum Direction {
+    Request,
+    Reply,
+}
+
 impl From<(&str, &str, &str)> for InvalidRequest {
     fn from(t: (&str, &str, &str)) -> InvalidRequest {
         InvalidRequest {

--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 
 use crate::qpaxos::{Instance, InstanceId, InstanceIdVec, OpCode};
-use crate::replica::{Replica, ReplicaError};
+use crate::replica::Replica;
+use storage::StorageError;
 use storage::WriteEntry;
 
 thread_local! {
@@ -72,7 +73,7 @@ impl Replica {
     pub fn execute_commands(
         &self,
         mut insts: Vec<Instance>,
-    ) -> Result<Vec<InstanceId>, ReplicaError> {
+    ) -> Result<Vec<InstanceId>, StorageError> {
         let mut rst = Vec::with_capacity(insts.len());
         let mut entrys: Vec<WriteEntry> = Vec::with_capacity(insts.len());
         let mut existed = HashMap::new();
@@ -135,7 +136,7 @@ impl Replica {
     pub fn execute_instances(
         &self,
         mut insts: Vec<Instance>,
-    ) -> Result<Vec<InstanceId>, ReplicaError> {
+    ) -> Result<Vec<InstanceId>, StorageError> {
         let mut early = vec![false; insts.len()];
         let mut late = vec![false; insts.len()];
         let mut can_exec = Vec::with_capacity(insts.len());
@@ -193,7 +194,7 @@ impl Replica {
     pub fn get_insts_if_committed(
         &self,
         inst_ids: &Vec<InstanceId>,
-    ) -> Result<Vec<Instance>, ReplicaError> {
+    ) -> Result<Vec<Instance>, StorageError> {
         let mut rst = Vec::new();
         let mut recover_iids = InstanceIdVec::from([0; 0]);
 
@@ -219,7 +220,7 @@ impl Replica {
         Ok(rst)
     }
 
-    pub fn execute(&self) -> Result<Vec<InstanceId>, ReplicaError> {
+    pub fn execute(&self) -> Result<Vec<InstanceId>, StorageError> {
         let mut exec_up_to = InstanceIdVec::from([0; 0]);
         let mut smallest_inst_ids = InstanceIdVec::from([0; 0]);
         for rid in self.group_replica_ids.iter() {

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -6,6 +6,7 @@ use crate::replica::ReplicaError;
 use crate::replication::RpcHandlerError;
 use crate::Iter;
 use crate::Storage;
+use storage::StorageError;
 
 /// ref_or_bug extracts a immutable ref from an Option.
 /// If the Option is None a bug handler is triggered.
@@ -101,7 +102,7 @@ impl Replica {
     /// new_instance creates a new instance with initial_deps and deps initialized and stores it in
     /// replica storage.
     /// initial_deps and deps could contains (x, -1) if a leader has not yet propose any instance.
-    pub fn new_instance(&self, cmds: &[Command]) -> Result<Instance, ReplicaError> {
+    pub fn new_instance(&self, cmds: &[Command]) -> Result<Instance, StorageError> {
         // TODO locking
         // TODO do not need to store max instance id, store it in replica and when starting, scan
         // backward to find the max

--- a/components/epaxos/src/replication/errors.rs
+++ b/components/epaxos/src/replication/errors.rs
@@ -93,10 +93,7 @@ quick_error! {
         NotEnoughQuorum(phase: InstanceStatus, want: i32, got: i32) {
             display("{:?}: want at least {} replies, but:{}", phase, want, got)
         }
-        Replica(re: ReplicaError) {
-            from(re: ReplicaError) -> (re)
-        }
-        Handler(e: RpcHandlerError) {
+        RpcHandler(e: RpcHandlerError) {
             from(e: RpcHandlerError) -> (e)
         }
         Storage(e: StorageError) {

--- a/components/epaxos/src/replication/hdlreply.rs
+++ b/components/epaxos/src/replication/hdlreply.rs
@@ -1,3 +1,4 @@
+use crate::qpaxos::Direction;
 use crate::qpaxos::*;
 use crate::replica::*;
 use crate::replication::RpcHandlerError;
@@ -23,7 +24,12 @@ pub fn handle_fast_accept_reply(
 ) -> Result<(), RpcHandlerError> {
     // A duplicated message is received. Just ignore.
     if st.fast_replied.contains_key(&from_rid) {
-        return Err(RpcHandlerError::Dup(from_rid));
+        return Err(RpcHandlerError::DupRpc(
+            InstanceStatus::FastAccepted,
+            Direction::Reply,
+            from_rid,
+            st.instance.instance_id.unwrap(),
+        ));
     }
 
     st.fast_replied.insert(from_rid, true);
@@ -84,7 +90,12 @@ pub fn handle_accept_reply(
     // TODO test duplicated message
     // A duplicated message is received. Just ignore.
     if st.accept_replied.contains_key(&from_rid) {
-        return Err(RpcHandlerError::Dup(from_rid));
+        return Err(RpcHandlerError::DupRpc(
+            InstanceStatus::Accepted,
+            Direction::Reply,
+            from_rid,
+            st.instance.instance_id.unwrap(),
+        ));
     }
     st.accept_replied.insert(from_rid, true);
 

--- a/components/epaxos/src/replication/test_hdlreply.rs
+++ b/components/epaxos/src/replication/test_hdlreply.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::qpaxos::Direction;
 use crate::qpaxos::*;
 use crate::replica::*;
 use crate::replication::*;
@@ -188,7 +189,15 @@ fn test_handle_fast_accept_reply() {
         let from_rid = 4;
 
         let r = handle_fast_accept_reply(&mut st, from_rid, &repl);
-        assert_eq!(r.err().unwrap(), RpcHandlerError::Dup(from_rid));
+        assert_eq!(
+            r.err().unwrap(),
+            RpcHandlerError::DupRpc(
+                InstanceStatus::FastAccepted,
+                Direction::Reply,
+                from_rid,
+                st.instance.instance_id.unwrap()
+            )
+        );
         assert_eq!(true, st.fast_replied.contains_key(&from_rid));
 
         get!(st.fast_oks, &from_rid, None);


### PR DESCRIPTION

### refactor: ReplicationError does not need to include ReplicaError


### refactor: exec only need to return StorageError, not ReplicaError


### refactor: RpcHandlerError::Dup rename to DupRpc and add more info to error definition




## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
