### PR TITLE
refactor:

### DIFF
--- a/components/epaxos/build.rs
+++ b/components/epaxos/build.rs
@@ -20,6 +20,14 @@ fn main() {
         .type_attribute("InvalidRequest", "#[derive(Eq)]")
         .type_attribute("InstanceIdVec", "#[derive(derive_more::From)]")
         .type_attribute(
+            "ReplicateRequest.phase",
+            "#[derive(derive_more::From, derive_more::TryInto)]",
+        )
+        .type_attribute(
+            "ReplicateReply.phase",
+            "#[derive(derive_more::From, derive_more::TryInto)]",
+        )
+        .type_attribute(
             "BallotNum",
             "#[derive(Copy, Eq, Ord, PartialOrd, derive_more::From)]",
         )

--- a/components/epaxos/src/protos/instance.proto
+++ b/components/epaxos/src/protos/instance.proto
@@ -22,7 +22,6 @@ message BallotNum {
 // Instance is the internal representation of a client request.
 message Instance {
 
-    BallotNum last_ballot  = 11;
     BallotNum ballot       = 12;
     InstanceId instance_id = 13;
     repeated Command cmds  = 21;

--- a/components/epaxos/src/protos/message.proto
+++ b/components/epaxos/src/protos/message.proto
@@ -23,63 +23,66 @@ enum RequestType {
 // 51~60: for commit.
 
 
-message RequestCommon {
-    int64 to_replica_id = 2;
-
-    // Sender's ballot
-    BallotNum ballot = 12;
-    InstanceId instance_id = 13;
-}
 message FastAcceptRequest {
-    RequestCommon cmn = 1;
     repeated Command     cmds           = 21;
     InstanceIdVec        initial_deps   = 31;
-    repeated bool                deps_committed = 33;
+    repeated bool        deps_committed = 33;
 }
 message AcceptRequest {
-    RequestCommon cmn = 1;
     InstanceIdVec final_deps = 41;
 }
 message CommitRequest {
-    RequestCommon cmn = 1;
     repeated Command     cmds           = 21;
     InstanceIdVec        final_deps     = 41;
 }
 message PrepareRequest {
-    RequestCommon cmn = 1;
     // TODO prepare does not need cmds to find conflicting in our algorithm.
     //      need proof
-    // repeated Command     cmds           = 21;
+    // repeated Command  cmds           = 21;
 }
 
+message ReplicateRequest {
 
-message ReplyCommon {
-    // The ballot stored on acceptor before handling a request.
+    int64 to_replica_id    = 2;
 
-    BallotNum  last_ballot = 11;
+    // Sender's ballot
+    BallotNum ballot       = 12;
     InstanceId instance_id = 13;
+
+    oneof phase {
+        FastAcceptRequest fast    = 100;
+        AcceptRequest     accept  = 101;
+        CommitRequest     commit  = 102;
+        PrepareRequest    prepare = 103;
+    }
 }
+
 message FastAcceptReply {
     // deps_status describe what status a dependent instance is in.
     // Only `deps` needs these information in order to commit on fast-path.
 
-    ReplyCommon         cmn            = 1;
-    QError              err            = 5;
     InstanceIdVec       deps           = 32;
     repeated bool       deps_committed = 33;
 }
-message AcceptReply {
-    ReplyCommon cmn = 1;
-    QError      err = 5;
-}
-message CommitReply {
-    ReplyCommon cmn = 1;
-    QError      err = 5;
-}
+message AcceptReply { }
+message CommitReply { }
 message PrepareReply {
-    ReplyCommon         cmn        = 1;
-    QError              err        = 5;
     InstanceIdVec       deps       = 32;
     InstanceIdVec       final_deps = 41;
     bool                committed  = 51;
+}
+
+message ReplicateReply {
+
+    QError     err         = 5;
+    // The ballot stored on acceptor before handling a request.
+    BallotNum  last_ballot = 11;
+    InstanceId instance_id = 13;
+
+    oneof phase {
+        FastAcceptReply fast    = 100;
+        AcceptReply     accept  = 101;
+        CommitReply     commit  = 102;
+        PrepareReply    prepare = 103;
+    }
 }

--- a/components/epaxos/src/protos/qpaxos.proto
+++ b/components/epaxos/src/protos/qpaxos.proto
@@ -5,8 +5,5 @@ package qpaxos;
 import "message.proto";
 
 service QPaxos {
-    rpc fast_accept (FastAcceptRequest) returns (FastAcceptReply) {}
-    rpc accept      (AcceptRequest)     returns (AcceptReply) {}
-    rpc commit      (CommitRequest)     returns (CommitReply) {}
-    rpc prepare     (PrepareRequest)    returns (PrepareReply) {}
+    rpc replicate   (ReplicateRequest)  returns (ReplicateReply) {}
 }

--- a/components/epaxos/src/qpaxos/display.rs
+++ b/components/epaxos/src/qpaxos/display.rs
@@ -82,9 +82,8 @@ impl_tostr_ext!(InstanceId, "({}, {})", replica_id, idx);
 impl_tostr_ext!(BallotNum, "({}, {}, {})", epoch, num, replica_id);
 impl_tostr_ext!(
     Instance,
-    "{{id:{}, blt:{}->{}, cmds:{}, deps:{}{}{}, c/e:{}/{}}}",
+    "{{id:{}, blt:{}, cmds:{}, deps:{}{}{}, c/e:{}/{}}}",
     instance_id,
-    last_ballot,
     ballot,
     cmds,
     initial_deps,

--- a/components/epaxos/src/qpaxos/macros.rs
+++ b/components/epaxos/src/qpaxos/macros.rs
@@ -71,7 +71,7 @@ macro_rules! init_inst {
 /// deps: [(replica_id, idx)...]; `deps` can be "withdeps" as a flag: clone initial_deps as its value.
 ///
 /// Supported pattern:
-/// inst!(instance_id, last_ballot, ballot, cmds, initial_deps, deps, final_deps, committed, executed)
+/// inst!(instance_id, ballot, cmds, initial_deps, deps, final_deps, committed, executed)
 /// inst!(instance_id, ballot, cmds, initial_deps, deps)
 /// inst!(instance_id, ballot, cmds, initial_deps, "withdeps")
 /// inst!(instance_id, ballot, cmds, initial_deps)
@@ -158,7 +158,6 @@ macro_rules! inst {
 
     // all arg
     ($id:expr,
-     ($lepoch:expr, $lnum:expr, $lbrid:expr),
      ($epoch:expr, $num:expr, $brid:expr),
      [$( ($op:expr, $key:expr, $val:expr)),*],
      [$( ($idep_rid:expr, $idep_idx:expr)),*],
@@ -170,7 +169,6 @@ macro_rules! inst {
      ) => {
         Instance {
             instance_id: Some($id.into()),
-            last_ballot: Some(($lepoch, $lnum, $lbrid).into()),
             ballot: Some(($epoch, $num, $brid).into()),
             cmds: cmds![$( ($op, $key, $val)),*].into(),
             initial_deps: Some(

--- a/components/epaxos/src/qpaxos/t.rs
+++ b/components/epaxos/src/qpaxos/t.rs
@@ -2,6 +2,9 @@ use super::*;
 // Message is required to use to use method in trait Message.
 use prost::Message;
 
+use crate::qpaxos::ReplicateReply;
+use crate::qpaxos::ReplicateRequest;
+
 use std::str;
 
 fn new_foo_inst() -> Instance {
@@ -16,14 +19,12 @@ fn new_foo_inst() -> Instance {
     let cmd2 = Command::of(OpCode::Get, "k2".as_bytes(), "v2".as_bytes());
     let cmds = vec![cmd1, cmd2];
     let ballot = (0, 0, replica).into();
-    let ballot2 = (1, 2, replica).into();
 
     let mut inst = Instance::of(&cmds[..], ballot, &initial_deps[..]);
     // TODO move these to Instance::new_instance
     inst.instance_id = Some(inst_id1);
     inst.deps = Some(vec![inst_id2].into());
     inst.final_deps = Some(vec![inst_id3].into());
-    inst.last_ballot = Some(ballot2);
 
     inst
 }
@@ -32,16 +33,9 @@ fn new_foo_inst() -> Instance {
 
 macro_rules! test_request_common {
     ($msg:ident, $inst:ident, $to_rid:expr) => {
-        assert_eq!($inst.ballot, $msg.cmn.as_ref().unwrap().ballot);
-        assert_eq!($inst.instance_id, $msg.cmn.as_ref().unwrap().instance_id);
-        assert_eq!($to_rid, $msg.cmn.as_ref().unwrap().to_replica_id);
-    };
-}
-
-macro_rules! test_reply_common {
-    ($msg:ident, $inst:ident) => {
-        assert_eq!($inst.last_ballot, $msg.cmn.as_ref().unwrap().last_ballot);
-        assert_eq!($inst.instance_id, $msg.cmn.as_ref().unwrap().instance_id);
+        assert_eq!($inst.ballot, $msg.ballot);
+        assert_eq!($inst.instance_id, $msg.instance_id);
+        assert_eq!($to_rid, $msg.to_replica_id);
     };
 }
 
@@ -244,25 +238,10 @@ fn test_request_prepare_pb() {
     let inst = new_foo_inst();
 
     let pp = MakeRequest::prepare(100, &inst);
+    test_enc_dec!(pp, ReplicateRequest);
 
     test_request_common!(pp, inst, 100);
     // prepare has no other fields.
-
-    test_enc_dec!(pp, PrepareRequest);
-}
-
-#[test]
-fn test_reply_prepare_pb() {
-    let inst = new_foo_inst();
-
-    let pp = MakeReply::prepare(&inst);
-
-    test_reply_common!(pp, inst);
-    assert_eq!(inst.deps, pp.deps);
-    assert_eq!(inst.final_deps, pp.final_deps);
-    assert_eq!(inst.committed, pp.committed);
-
-    test_enc_dec!(pp, PrepareReply);
 }
 
 #[test]
@@ -271,27 +250,14 @@ fn test_request_fast_accpt_pb() {
 
     let deps_committed = &[true, false];
     let pp = MakeRequest::fast_accept(100, &inst, deps_committed);
+    test_enc_dec!(pp, ReplicateRequest);
+
+    let req: FastAcceptRequest = pp.phase.unwrap().try_into().unwrap();
 
     test_request_common!(pp, inst, 100);
-    assert_eq!(inst.cmds, pp.cmds);
-    assert_eq!(inst.initial_deps, pp.initial_deps);
-    assert_eq!(deps_committed.to_vec(), pp.deps_committed);
-
-    test_enc_dec!(pp, FastAcceptRequest);
-}
-
-#[test]
-fn test_reply_fast_accept_pb() {
-    let inst = new_foo_inst();
-
-    let deps_committed = &[true, false];
-    let pp = MakeReply::fast_accept(&inst, deps_committed);
-
-    test_reply_common!(pp, inst);
-    assert_eq!(inst.deps, pp.deps);
-    assert_eq!(deps_committed.to_vec(), pp.deps_committed);
-
-    test_enc_dec!(pp, FastAcceptReply);
+    assert_eq!(inst.cmds, req.cmds);
+    assert_eq!(inst.initial_deps, req.initial_deps);
+    assert_eq!(deps_committed.to_vec(), req.deps_committed);
 }
 
 #[test]
@@ -299,23 +265,12 @@ fn test_request_accept_pb() {
     let inst = new_foo_inst();
 
     let pp = MakeRequest::accept(100, &inst);
+    test_enc_dec!(pp, ReplicateRequest);
+
+    let req: AcceptRequest = pp.phase.unwrap().try_into().unwrap();
 
     test_request_common!(pp, inst, 100);
-    assert_eq!(inst.final_deps, pp.final_deps);
-
-    test_enc_dec!(pp, AcceptRequest);
-}
-
-#[test]
-fn test_reply_accept_pb() {
-    let inst = new_foo_inst();
-
-    let pp = MakeReply::accept(&inst);
-
-    test_reply_common!(pp, inst);
-    // no other fields.
-
-    test_enc_dec!(pp, AcceptReply);
+    assert_eq!(inst.final_deps, req.final_deps);
 }
 
 #[test]
@@ -323,22 +278,29 @@ fn test_request_commit_pb() {
     let inst = new_foo_inst();
 
     let pp = MakeRequest::commit(100, &inst);
+    test_enc_dec!(pp, ReplicateRequest);
+
+    let req: CommitRequest = pp.phase.unwrap().try_into().unwrap();
 
     test_request_common!(pp, inst, 100);
-    assert_eq!(inst.cmds, pp.cmds);
-    assert_eq!(inst.final_deps, pp.final_deps);
-
-    test_enc_dec!(pp, CommitRequest);
+    assert_eq!(inst.cmds, req.cmds);
+    assert_eq!(inst.final_deps, req.final_deps);
 }
 
 #[test]
-fn test_reply_commit_pb() {
-    let inst = new_foo_inst();
+fn test_replicate_reply_pb() {
+    let reply = ReplicateReply {
+        err: None,
+        last_ballot: Some((1, 2, 3).into()),
+        instance_id: Some(instid!(1, 2)),
+        phase: Some(
+            FastAcceptReply {
+                deps: Some(instids![(1, 2), (3, 4)].into()),
+                deps_committed: vec![true],
+            }
+            .into(),
+        ),
+    };
 
-    let pp = MakeReply::commit(&inst);
-
-    test_reply_common!(pp, inst);
-    // no other fields.
-
-    test_enc_dec!(pp, CommitReply);
+    test_enc_dec!(reply, ReplicateReply);
 }

--- a/components/epaxos/src/qpaxos/test_display.rs
+++ b/components/epaxos/src/qpaxos/test_display.rs
@@ -87,7 +87,6 @@ fn test_display_instance() {
     let inst = inst!(
         (1, 2),
         (2, 3, 4),
-        (4, 5, 6),
         [("Set", "a", "b"), ("Get", "c", "d")],
         [(2, 3), (3, 4)],
         [(3, 4), (4, 5)],
@@ -95,6 +94,6 @@ fn test_display_instance() {
         false,
         true,
     );
-    assert_eq!("{id:(1, 2), blt:(2, 3, 4)->(4, 5, 6), cmds:[Set:a=b, Get:c], deps:[(2, 3), (3, 4)][(3, 4), (4, 5)][(4, 5), (5, 6)], c/e:false/true}",
+    assert_eq!("{id:(1, 2), blt:(2, 3, 4), cmds:[Set:a=b, Get:c], deps:[(2, 3), (3, 4)][(3, 4), (4, 5)][(4, 5), (5, 6)], c/e:false/true}",
     format!("{}", inst));
 }

--- a/components/epaxos/src/qpaxos/test_instance.rs
+++ b/components/epaxos/src/qpaxos/test_instance.rs
@@ -37,7 +37,6 @@ fn test_macro_ballot() {
 fn test_macro_inst_all_arg() {
     let want = Instance {
         instance_id: Some((1, 2).into()),
-        last_ballot: Some((4, 5, 2).into()),
         ballot: Some((3, 4, 2).into()),
         cmds: vec![("Set", "x", "y").into(), ("Get", "a", "b").into()],
         initial_deps: Some(InstanceIdVec {
@@ -57,7 +56,6 @@ fn test_macro_inst_all_arg() {
         want,
         inst!(
             (1, 2),
-            (4, 5, 2),
             (3, 4, 2),
             [("Set", "x", "y"), ("Get", "a", "b")],
             [(11, 12), (13, 14)],
@@ -73,7 +71,6 @@ fn test_macro_inst_all_arg() {
         want,
         inst!(
             InstanceId::from((1, 2)),
-            (4, 5, 2),
             (3, 4, 2),
             [("Set", "x", "y"), ("Get", "a", "b")],
             [(11, 12), (13, 14)],
@@ -89,7 +86,6 @@ fn test_macro_inst_all_arg() {
 fn test_macro_inst() {
     let mut want = Instance {
         instance_id: Some((1, 2).into()),
-        last_ballot: None,
         ballot: Some((3, 4, 1).into()),
         cmds: vec![("Set", "x", "y").into(), ("Get", "a", "b").into()],
         initial_deps: Some(InstanceIdVec {

--- a/components/epaxos/src/qpaxos/test_macros.rs
+++ b/components/epaxos/src/qpaxos/test_macros.rs
@@ -9,7 +9,6 @@ use crate::qpaxos::*;
 fn test_macro_init_inst() {
     let want = Instance {
         instance_id: Some((1, 2).into()),
-        last_ballot: None,
         ballot: Some((0, 0, 1).into()),
         cmds: vec![("Set", "x", "y").into(), ("Get", "a", "b").into()],
         initial_deps: Some(InstanceIdVec {

--- a/components/epaxos/src/replication/broadcast.rs
+++ b/components/epaxos/src/replication/broadcast.rs
@@ -1,74 +1,39 @@
 use tonic::Response;
 
-use crate::qpaxos::AcceptReply;
-use crate::qpaxos::CommitReply;
-use crate::qpaxos::FastAcceptReply;
-use crate::qpaxos::Instance;
-use crate::qpaxos::MakeRequest;
-use crate::qpaxos::PrepareReply;
 use crate::qpaxos::QPaxosClient;
 use crate::qpaxos::ReplicaId;
+use crate::qpaxos::ReplicateReply;
+use crate::qpaxos::ReplicateRequest;
 use crate::replica::ReplicaPeer;
 
-macro_rules! bcast_msg {
-    ($peers:expr, $make_req:expr, $func:ident) => {{
-        let mut rst = Vec::with_capacity($peers.len());
-        for p in $peers.iter() {
-            let mut client = match QPaxosClient::connect(p.addr.clone()).await {
-                Ok(c) => c,
-                // TODO just ignore the err
-                Err(e) => {
-                    println!("{:?} while connect to {:?}", e, &p.addr);
-                    continue;
-                }
-            };
+pub async fn bcast_msg(
+    peers: &[ReplicaPeer],
+    req: ReplicateRequest,
+) -> Vec<(ReplicaId, Response<ReplicateReply>)> {
+    let mut rst = Vec::with_capacity(peers.len());
+    for p in peers.iter() {
+        let mut client = match QPaxosClient::connect(p.addr.clone()).await {
+            Ok(c) => c,
+            // TODO just ignore the err
+            Err(e) => {
+                println!("{:?} while connect to {:?}", e, &p.addr);
+                continue;
+            }
+        };
 
-            let req = $make_req(p.replica_id);
-            let repl = match client.$func(req).await {
-                Ok(r) => r,
-                // TODO just ignore the err
-                Err(e) => {
-                    println!("{:?} while request to {:?}", e, &p.addr);
-                    continue;
-                }
-            };
+        let mut r = req.clone();
+        r.to_replica_id = p.replica_id;
+        let repl = match client.replicate(r).await {
+            Ok(r) => r,
+            // TODO just ignore the err
+            Err(e) => {
+                println!("{:?} while request to {:?}", e, &p.addr);
+                continue;
+            }
+        };
 
-            rst.push((p.replica_id, repl));
-        }
+        rst.push((p.replica_id, repl));
+    }
 
-        return rst;
-    }};
-}
-
-pub async fn bcast_fast_accept(
-    peers: &Vec<ReplicaPeer>,
-    inst: &Instance,
-    deps_committed: &[bool],
-) -> Vec<(ReplicaId, Response<FastAcceptReply>)> {
-    bcast_msg!(
-        peers,
-        |rid| MakeRequest::fast_accept(rid, inst, deps_committed),
-        fast_accept
-    );
-}
-
-pub async fn bcast_accept(
-    peers: &Vec<ReplicaPeer>,
-    inst: &Instance,
-) -> Vec<(ReplicaId, Response<AcceptReply>)> {
-    bcast_msg!(peers, |rid| MakeRequest::accept(rid, inst), accept);
-}
-
-pub async fn bcast_commit(
-    peers: &Vec<ReplicaPeer>,
-    inst: &Instance,
-) -> Vec<(ReplicaId, Response<CommitReply>)> {
-    bcast_msg!(peers, |rid| MakeRequest::commit(rid, inst), commit);
-}
-
-pub async fn bcast_prepare(
-    peers: &Vec<ReplicaPeer>,
-    inst: &Instance,
-) -> Vec<(ReplicaId, Response<PrepareReply>)> {
-    bcast_msg!(peers, |rid| MakeRequest::prepare(rid, inst), prepare);
+    return rst;
 }

--- a/components/epaxos/src/replication/test_broadcast.rs
+++ b/components/epaxos/src/replication/test_broadcast.rs
@@ -1,18 +1,18 @@
 use crate::qpaxos::Command;
 use crate::qpaxos::Instance;
 use crate::qpaxos::InstanceId;
-use crate::replication::bcast_accept;
-use crate::replication::bcast_commit;
-use crate::replication::bcast_fast_accept;
-use crate::replication::bcast_prepare;
+use crate::qpaxos::MakeRequest;
+use crate::replication::bcast_msg;
 use crate::testutil::TestCluster;
 
 #[tokio::main]
-async fn _bcast_fast_accept() {
+async fn _bcast() {
     let mut tc = TestCluster::new(3);
     tc.start().await;
     let inst = foo_inst!((0, 1), "key_x", [(0, 0), (1, 0), (2, 0)]);
-    let r = bcast_fast_accept(&tc.replicas[0].peers, &inst, &[true, true, true]).await;
+    let req = MakeRequest::fast_accept(0, &inst, &[true, true, true]);
+
+    let r = bcast_msg(&tc.replicas[0].peers, req).await;
 
     println!("receive fast accept replys: {:?}", r);
     // not contain self
@@ -20,57 +20,6 @@ async fn _bcast_fast_accept() {
 }
 
 #[test]
-fn test_bcast_fast_accept() {
-    _bcast_fast_accept();
-}
-
-#[tokio::main]
-async fn _bcast_accept() {
-    let mut tc = TestCluster::new(3);
-    tc.start().await;
-    let inst = foo_inst!((0, 1), "key_x", [(0, 0), (1, 0), (2, 0)]);
-    let r = bcast_accept(&tc.replicas[0].peers, &inst).await;
-
-    println!("receive accept replys: {:?}", r);
-    // not contain self
-    assert_eq!(2, r.len());
-}
-
-#[test]
-fn test_bcast_accept() {
-    _bcast_accept();
-}
-
-#[tokio::main]
-async fn _bcast_commit() {
-    let mut tc = TestCluster::new(3);
-    tc.start().await;
-    let inst = foo_inst!((0, 1), "key_x", [(0, 0), (1, 0), (2, 0)]);
-    let r = bcast_commit(&tc.replicas[0].peers, &inst).await;
-
-    println!("receive commit replys: {:?}", r);
-    // not contain self
-    assert_eq!(2, r.len());
-}
-
-#[test]
-fn test_bcast_commit() {
-    _bcast_commit();
-}
-
-#[tokio::main]
-async fn _bcast_prepare() {
-    let mut tc = TestCluster::new(3);
-    tc.start().await;
-    let inst = foo_inst!((0, 1), "key_x", [(0, 0), (1, 0), (2, 0)]);
-    let r = bcast_prepare(&tc.replicas[0].peers, &inst).await;
-
-    println!("receive prepare replys: {:?}", r);
-    // not contain self
-    assert_eq!(2, r.len());
-}
-
-#[test]
-fn test_bcast_prepare() {
-    _bcast_prepare();
+fn test_bcast_replicate_request() {
+    _bcast();
 }

--- a/components/epaxos/src/service/service.rs
+++ b/components/epaxos/src/service/service.rs
@@ -1,17 +1,8 @@
-use crate::qpaxos::AcceptReply;
-use crate::qpaxos::AcceptRequest;
-use crate::qpaxos::CommitReply;
-use crate::qpaxos::CommitRequest;
-use crate::qpaxos::FastAcceptReply;
-use crate::qpaxos::FastAcceptRequest;
-use crate::qpaxos::Instance;
-use crate::qpaxos::MakeReply;
-use crate::qpaxos::PrepareReply;
-use crate::qpaxos::PrepareRequest;
 use crate::qpaxos::ProtocolError;
 use crate::qpaxos::QPaxos;
-use crate::qpaxos::RequestCommon;
-use crate::replica::Replica;
+use crate::qpaxos::ReplicateReply;
+use crate::qpaxos::ReplicateRequest;
+use crate::replication::RpcHandlerError;
 use crate::ServerData;
 use std::sync::Arc;
 
@@ -27,92 +18,38 @@ impl MyQPaxos {
     pub fn new(server_data: Arc<ServerData>) -> Self {
         MyQPaxos { server_data }
     }
-    pub fn get_replica(&self, cmn: &Option<RequestCommon>) -> Result<&Replica, ProtocolError> {
-        let cmn = cmn.as_ref().ok_or(ProtocolError::LackOf("cmn".into()))?;
-        let rid = cmn.to_replica_id;
-        let r = self.server_data.local_replicas.get(&rid);
-        let r = r.ok_or(ProtocolError::NoSuchReplica(rid, 0))?;
-        Ok(r)
-    }
 }
 
 #[tonic::async_trait]
 impl QPaxos for MyQPaxos {
-    async fn fast_accept(
+    async fn replicate(
         &self,
-        request: Request<FastAcceptRequest>,
-    ) -> Result<Response<FastAcceptReply>, Status> {
+        request: Request<ReplicateRequest>,
+    ) -> Result<Response<ReplicateReply>, Status> {
         println!("Got a request: {:?}", request);
-        let req = request.get_ref();
-        let r = self.get_replica(&req.cmn);
-        let r = match r {
+
+        let req = request.into_inner();
+
+        let reply = handle_replicate_request(self, req);
+        let reply = match reply {
             Ok(v) => v,
-            Err(e) => {
-                let reply = FastAcceptReply {
-                    err: Some(e.into()),
-                    ..Default::default()
-                };
-                return Ok(Response::new(reply));
-            }
+            Err(e) => ReplicateReply {
+                err: Some(e.into()),
+                ..Default::default()
+            },
         };
-
-        let reply = r.handle_fast_accept(request.get_ref());
         Ok(Response::new(reply))
     }
+}
 
-    async fn accept(
-        &self,
-        request: Request<AcceptRequest>,
-    ) -> Result<Response<AcceptReply>, Status> {
-        println!("Got a request: {:?}", request);
-        let req = request.get_ref();
-        let r = self.get_replica(&req.cmn);
-        let r = match r {
-            Ok(v) => v,
-            Err(e) => {
-                let reply = AcceptReply {
-                    err: Some(e.into()),
-                    ..Default::default()
-                };
-                return Ok(Response::new(reply));
-            }
-        };
-        let reply = r.handle_accept(request.get_ref());
-        Ok(Response::new(reply))
-    }
+pub fn handle_replicate_request(
+    sv: &MyQPaxos,
+    req: ReplicateRequest,
+) -> Result<ReplicateReply, RpcHandlerError> {
+    // TODO test replica not found
+    let rid = req.to_replica_id;
+    let r = sv.server_data.local_replicas.get(&rid);
+    let r = r.ok_or(ProtocolError::NoSuchReplica(rid, 0))?;
 
-    async fn commit(
-        &self,
-        request: Request<CommitRequest>,
-    ) -> Result<Response<CommitReply>, Status> {
-        println!("Got a request: {:?}", request);
-        let req = request.get_ref();
-        let r = self.get_replica(&req.cmn);
-        let r = match r {
-            Ok(v) => v,
-            Err(e) => {
-                let reply = CommitReply {
-                    err: Some(e.into()),
-                    ..Default::default()
-                };
-                return Ok(Response::new(reply));
-            }
-        };
-        let reply = r.handle_commit(request.get_ref());
-        Ok(Response::new(reply))
-    }
-
-    async fn prepare(
-        &self,
-        request: Request<PrepareRequest>,
-    ) -> Result<Response<PrepareReply>, Status> {
-        // TODO I did nothing but let the test pass happily
-        let inst = Instance {
-            ..Default::default()
-        };
-
-        let reply = MakeReply::prepare(&inst);
-        println!("Got a request: {:?}", request);
-        Ok(Response::new(reply))
-    }
+    r.handle_replicate(req)
 }

--- a/components/epaxos/tests/test_repl_server.rs
+++ b/components/epaxos/tests/test_repl_server.rs
@@ -56,7 +56,7 @@ async fn _repl_server() {
     // let request = message::Request::accept().into();
     let request = qp::MakeRequest::accept(0, &inst);
 
-    let response = client.accept(request).await.unwrap();
+    let response = client.replicate(request).await.unwrap();
 
     println!("RESPONSE={:?}", response);
 

--- a/tests/test_replica.rs
+++ b/tests/test_replica.rs
@@ -25,7 +25,6 @@ async fn _test_replica_exec_thread() {
         (
             inst!(
                 (1, 0),
-                (4, 5, 2),
                 (3, 4, 2),
                 [("Set", "x", "y")],
                 [(1, 0)],
@@ -39,7 +38,6 @@ async fn _test_replica_exec_thread() {
         (
             inst!(
                 (1, 1),
-                (4, 5, 2),
                 (3, 4, 2),
                 [("Set", "z", "a")],
                 [(1, 0)],

--- a/tests/test_setget.rs
+++ b/tests/test_setget.rs
@@ -94,7 +94,7 @@ async fn connect_repl() {
 
     let request = MakeRequest::accept(0, &inst);
 
-    let response = client.accept(request).await.unwrap();
+    let response = client.replicate(request).await.unwrap();
 
     println!("RESPONSE={:?}", response);
 }


### PR DESCRIPTION
-   Use one request/reply pair for all replication phases:
    `ReplicateRequest/ReplicateReply`.

    Info of different phases are stored in a `oneof` field: `phase`.

    ```
    message ReplicateRequest {
        int64 to_replica_id    = 2;
        BallotNum ballot       = 12;
        InstanceId instance_id = 13;
        oneof phase {
            FastAcceptRequest fast    = 100;
            AcceptRequest     accept  = 101;
            CommitRequest     commit  = 102;
            PrepareRequest    prepare = 103;
        }
    }
    ```

    To abtain `FastAcceptRequest` from `ReplicateRequest` use
    `TryInto`:
    `let f:FastAcceptRequest = req.phase.unwrap().try_into().unwrap()`.

-   Removes `Instance.last_ballot`. It does not need to be persisted.

-   Removes `MakeReply`. Replies are built during request handling.

-   Modifies `Replcia::handle_xxx()`, now they receive an instance to
    update instead of loading one from storage. This way we extract
    duplicated logics.

    Common field checking are moved to upper level: the replication
    service handler.

-   Replica provides a entry `handle_replicate` for all 4 phases.

-   `bcast_xxx()` are combined into one function `bcast_msg()`.



## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**
- **Document changes**
- **Test changes**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
