### PR TITLE
Namespace

### DIFF
--- a/components/epaxos/src/service/service.rs
+++ b/components/epaxos/src/service/service.rs
@@ -10,18 +10,18 @@ use tonic;
 use tonic::{Request, Response, Status};
 
 #[derive(Default)]
-pub struct MyQPaxos {
+pub struct QPaxosImpl {
     server_data: Arc<ServerData>,
 }
 
-impl MyQPaxos {
+impl QPaxosImpl {
     pub fn new(server_data: Arc<ServerData>) -> Self {
-        MyQPaxos { server_data }
+        QPaxosImpl { server_data }
     }
 }
 
 #[tonic::async_trait]
-impl QPaxos for MyQPaxos {
+impl QPaxos for QPaxosImpl {
     async fn replicate(
         &self,
         request: Request<ReplicateRequest>,
@@ -43,7 +43,7 @@ impl QPaxos for MyQPaxos {
 }
 
 pub fn handle_replicate_request(
-    sv: &MyQPaxos,
+    sv: &QPaxosImpl,
     req: ReplicateRequest,
 ) -> Result<ReplicateReply, RpcHandlerError> {
     // TODO test replica not found

--- a/components/epaxos/src/testutil.rs
+++ b/components/epaxos/src/testutil.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use crate::qpaxos::*;
 use crate::replica::{Replica, ReplicaPeer};
-use crate::MyQPaxos;
+use crate::QPaxosImpl;
 use crate::Storage;
 use storage::MemEngine;
 
@@ -149,7 +149,7 @@ impl TestCluster {
         for addr in self.addrs.iter() {
             let (tx, rx) = oneshot::channel::<()>();
 
-            let qp = MyQPaxos::default();
+            let qp = QPaxosImpl::default();
             let s = Server::builder().add_service(QPaxosServer::new(qp));
 
             // remove scheme

--- a/components/epaxos/tests/test_repl_server.rs
+++ b/components/epaxos/tests/test_repl_server.rs
@@ -49,11 +49,6 @@ async fn _repl_server() {
         ..Default::default()
     };
 
-    // Document said the request should be wrapped by a tonic::Request.
-    // Do not know why. It seems to work fine with a protobuf message.
-
-    // let request = Request::new(message::Request::accept());
-    // let request = message::Request::accept().into();
     let request = qp::MakeRequest::accept(0, &inst);
 
     let response = client.replicate(request).await.unwrap();

--- a/components/epaxos/tests/test_repl_server.rs
+++ b/components/epaxos/tests/test_repl_server.rs
@@ -7,7 +7,7 @@ use tokio::time::delay_for;
 use std::time::Duration;
 
 use epaxos::qpaxos as qp;
-use epaxos::MyQPaxos;
+use epaxos::QPaxosImpl;
 
 #[test]
 fn test_repl_server() {
@@ -23,7 +23,7 @@ async fn _repl_server() {
 
     // start a replication server in a coroutine
 
-    let qp = MyQPaxos::default();
+    let qp = QPaxosImpl::default();
     let s = Server::builder().add_service(qp::QPaxosServer::new(qp));
 
     tokio::spawn(async move {

--- a/components/storage/src/lib.rs
+++ b/components/storage/src/lib.rs
@@ -14,4 +14,7 @@ mod mem_engine;
 pub use mem_engine::*;
 
 #[cfg(test)]
+mod test_traits;
+
+#[cfg(test)]
 mod test_engine;

--- a/components/storage/src/mem_engine/memdb.rs
+++ b/components/storage/src/mem_engine/memdb.rs
@@ -20,32 +20,32 @@ impl Base for MemEngine {
 
     // TODO concurrent test
 
-    fn set(&self, cf: DBColumnFamily, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), StorageError> {
+    fn set(&self, cf: DBColumnFamily, key: &[u8], value: &[u8]) -> Result<(), StorageError> {
         let mut cfs = self._db.lock().unwrap();
         let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
-        bt.insert(key.clone(), value.clone());
+        bt.insert(key.to_vec(), value.to_vec());
         Ok(())
     }
 
-    fn get(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<Option<Vec<u8>>, StorageError> {
+    fn get(&self, cf: DBColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
         let mut cfs = self._db.lock().unwrap();
         let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
         Ok(bt.get(key).map(|x| x.clone()))
     }
 
-    fn delete(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<(), StorageError> {
+    fn delete(&self, cf: DBColumnFamily, key: &[u8]) -> Result<(), StorageError> {
         let mut cfs = self._db.lock().unwrap();
         let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
         bt.remove(key);
         Ok(())
     }
 
-    fn next(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn next(&self, cf: DBColumnFamily, key: &[u8], include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
         let mut cfs = self._db.lock().unwrap();
         let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
 
         for (k, v) in bt.range(key.to_vec()..) {
-            if include == false && key == k {
+            if include == false && key == k.as_slice() {
                 continue;
             }
 
@@ -55,12 +55,12 @@ impl Base for MemEngine {
         None
     }
 
-    fn prev(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn prev(&self, cf: DBColumnFamily, key: &[u8], include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
         let mut cfs = self._db.lock().unwrap();
         let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
 
         for (k, v) in bt.range((Unbounded, Included(key.to_vec()))).rev() {
-            if include == false && key == k {
+            if include == false && key == k.as_slice() {
                 continue;
             }
 

--- a/components/storage/src/mem_engine/memdb.rs
+++ b/components/storage/src/mem_engine/memdb.rs
@@ -18,29 +18,31 @@ impl Base for MemEngine {
     // TODO lock().unwrap() need to deal with poisoning
     // https://doc.rust-lang.org/std/sync/struct.Mutex.html#poisoning
 
+    // TODO concurrent test
+
     fn set(&self, cf: DBColumnFamily, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), StorageError> {
-        let mut bt = self._db.lock().unwrap();
-        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
+        let mut cfs = self._db.lock().unwrap();
+        let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
         bt.insert(key.clone(), value.clone());
         Ok(())
     }
 
     fn get(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<Option<Vec<u8>>, StorageError> {
-        let mut bt = self._db.lock().unwrap();
-        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
+        let mut cfs = self._db.lock().unwrap();
+        let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
         Ok(bt.get(key).map(|x| x.clone()))
     }
 
     fn delete(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<(), StorageError> {
-        let mut bt = self._db.lock().unwrap();
-        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
+        let mut cfs = self._db.lock().unwrap();
+        let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
         bt.remove(key);
         Ok(())
     }
 
     fn next(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
-        let mut bt = self._db.lock().unwrap();
-        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
+        let mut cfs = self._db.lock().unwrap();
+        let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
 
         for (k, v) in bt.range(key.to_vec()..) {
             if include == false && key == k {
@@ -54,8 +56,8 @@ impl Base for MemEngine {
     }
 
     fn prev(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
-        let mut bt = self._db.lock().unwrap();
-        let bt = bt.entry(cf.into()).or_insert(BTreeMap::new());
+        let mut cfs = self._db.lock().unwrap();
+        let bt = cfs.entry(cf.into()).or_insert(BTreeMap::new());
 
         for (k, v) in bt.range((Unbounded, Included(key.to_vec()))).rev() {
             if include == false && key == k {

--- a/components/storage/src/mem_engine/mod.rs
+++ b/components/storage/src/mem_engine/mod.rs
@@ -15,7 +15,7 @@ pub type MemBT = HashMap<&'static str, BTreeMap<Vec<u8>, Vec<u8>>>;
 /// ```text
 /// Replica-1 → Engine
 ///           ↗
-/// Replica-1
+/// Replica-2
 /// ```
 pub struct MemEngine {
     pub _db: Mutex<MemBT>,

--- a/components/storage/src/rocks_engine/engine.rs
+++ b/components/storage/src/rocks_engine/engine.rs
@@ -38,7 +38,7 @@ impl RocksDBEngine {
     fn _range(
         &self,
         cf: DBColumnFamily,
-        key: &Vec<u8>,
+        key: &[u8],
         include: bool,
         reverse: bool,
     ) -> Option<(Vec<u8>, Vec<u8>)> {
@@ -57,7 +57,7 @@ impl RocksDBEngine {
                     return Some(kv);
                 };
 
-                if &kv.0 != key {
+                if kv.0.as_slice() != key {
                     return Some(kv);
                 };
             }
@@ -79,27 +79,27 @@ impl RocksDBEngine {
 }
 
 impl Base for RocksDBEngine {
-    fn set(&self, cf: DBColumnFamily, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), StorageError> {
+    fn set(&self, cf: DBColumnFamily, key: &[u8], value: &[u8]) -> Result<(), StorageError> {
         let cfh = self._make_cf_handle(cf)?;
         Ok(self.db.put_cf(cfh, key, value)?)
     }
 
-    fn get(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<Option<Vec<u8>>, StorageError> {
+    fn get(&self, cf: DBColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
         let cfh = self._make_cf_handle(cf)?;
         let r = self.db.get_cf(cfh, key)?;
         Ok(r.map(|x| x.to_vec()))
     }
 
-    fn delete(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<(), StorageError> {
+    fn delete(&self, cf: DBColumnFamily, key: &[u8]) -> Result<(), StorageError> {
         let cfh = self._make_cf_handle(cf)?;
         Ok(self.db.delete_cf(cfh, key)?)
     }
 
-    fn next(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn next(&self, cf: DBColumnFamily, key: &[u8], include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
         self._range(cf, key, include, false)
     }
 
-    fn prev(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn prev(&self, cf: DBColumnFamily, key: &[u8], include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
         self._range(cf, key, include, true)
     }
 

--- a/components/storage/src/test_traits.rs
+++ b/components/storage/src/test_traits.rs
@@ -1,0 +1,16 @@
+use crate::NameSpace;
+
+#[test]
+fn test_namespace() {
+    assert_eq!("5/foo".as_bytes().to_vec(), 5i64.wrap_ns("foo".as_bytes()));
+    assert_eq!(
+        "bar/foo".as_bytes().to_vec(),
+        "bar".wrap_ns("foo".as_bytes())
+    );
+
+    assert_eq!(None, 5i64.unwrap_ns("6/foo".as_bytes()));
+    assert_eq!(
+        Some("foo".as_bytes().to_vec()),
+        5i64.unwrap_ns("5/foo".as_bytes())
+    );
+}

--- a/components/storage/src/traits.rs
+++ b/components/storage/src/traits.rs
@@ -60,44 +60,44 @@ pub trait ToKey {
 /// Base offer basic key-value access
 pub trait Base: Send + Sync {
     /// set a new key-value
-    fn set(&self, cf: DBColumnFamily, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), StorageError>;
+    fn set(&self, cf: DBColumnFamily, key: &[u8], value: &[u8]) -> Result<(), StorageError>;
 
     /// get an existing value with key
-    fn get(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<Option<Vec<u8>>, StorageError>;
+    fn get(&self, cf: DBColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError>;
 
     /// delete a key
-    fn delete(&self, cf: DBColumnFamily, key: &Vec<u8>) -> Result<(), StorageError>;
+    fn delete(&self, cf: DBColumnFamily, key: &[u8]) -> Result<(), StorageError>;
 
     /// next_kv returns a key-value pair greater than the given one(include=false),
     /// or greater or equal the given one(include=true)
-    fn next(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
+    fn next(&self, cf: DBColumnFamily, key: &[u8], include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
 
     /// prev_kv returns a key-value pair smaller than the given one(include=false),
     /// or smaller or equal the given one(include=true)
-    fn prev(&self, cf: DBColumnFamily, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
+    fn prev(&self, cf: DBColumnFamily, key: &[u8], include: bool) -> Option<(Vec<u8>, Vec<u8>)>;
 
     fn write_batch(&self, entrys: &Vec<WriteEntry>) -> Result<(), StorageError>;
 }
 
 /// KV offers functions to store user key/value.
 pub trait KV: Base {
-    fn set_kv(&self, key: &Vec<u8>, value: &Vec<u8>) -> Result<(), StorageError> {
+    fn set_kv(&self, key: &[u8], value: &[u8]) -> Result<(), StorageError> {
         self.set(DBColumnFamily::Default, key, value)
     }
 
-    fn get_kv(&self, key: &Vec<u8>) -> Result<Option<Vec<u8>>, StorageError> {
+    fn get_kv(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
         self.get(DBColumnFamily::Default, key)
     }
 
-    fn delete_kv(&self, key: &Vec<u8>) -> Result<(), StorageError> {
+    fn delete_kv(&self, key: &[u8]) -> Result<(), StorageError> {
         self.delete(DBColumnFamily::Default, key)
     }
 
-    fn next_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn next_kv(&self, key: &[u8], include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
         self.next(DBColumnFamily::Default, key, include)
     }
 
-    fn prev_kv(&self, key: &Vec<u8>, include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn prev_kv(&self, key: &[u8], include: bool) -> Option<(Vec<u8>, Vec<u8>)> {
         self.prev(DBColumnFamily::Default, key, include)
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -13,7 +13,7 @@ use tonic;
 use epaxos::conf::ClusterInfo;
 use epaxos::conf::NodeId;
 use epaxos::qpaxos::QPaxosServer;
-use epaxos::MyQPaxos;
+use epaxos::QPaxosImpl;
 use epaxos::ServerData;
 use epaxos::Storage;
 
@@ -122,7 +122,7 @@ impl Server {
         println!("serving: {}", api_addr);
 
         // TODO load cluster conf
-        let qp = MyQPaxos::default();
+        let qp = QPaxosImpl::default();
         let s = tonic::transport::Server::builder().add_service(QPaxosServer::new(qp));
 
         let j2 = tokio::spawn(async move {


### PR DESCRIPTION
### feat: NameSpace trait wraps key with a namespace


### refactor: storage: trait api use more general type &[u8] instead of &Vec<u8>


### fix: MemDB should not drop bt:MutexGuard early. Keeps a ref to it until operations done


### rename MyQPaxos to QPaxosImpl




## Type of change       <!-- delete irrelevant options. -->

- **Bug fix**           <!-- non-breaking change which fixes an issue -->
- **New feature**       <!-- non-breaking change which adds functionality -->
- **Breaking change**   <!-- fix or feature that would cause existing functionality to not work as expected -->
- **Refactoring**
- **Document changes**
- **Test changes**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
