### PR TITLE
Replica namespace

### DIFF
--- a/components/epaxos/Cargo.toml
+++ b/components/epaxos/Cargo.toml
@@ -27,6 +27,7 @@ derive_more = "0.99.3"
 num = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = { version = "0.8" }
+lazy_static = { version = "1.4.0" }
 storage = { path = "../storage" }
 
 # derive FromStr for enum

--- a/components/epaxos/src/lib.rs
+++ b/components/epaxos/src/lib.rs
@@ -28,10 +28,10 @@ pub use iters::*;
 use qpaxos::*;
 use std::sync::Arc;
 use storage::Engine;
+pub use storage::*;
 pub type Storage = Arc<dyn Engine<ReplicaId, InstanceId, InstanceId, Instance>>;
 
 use prost::Message;
-use storage::*;
 impl From<&Command> for WriteEntry {
     fn from(c: &Command) -> Self {
         if OpCode::Set as i32 == c.op {

--- a/components/epaxos/src/lib.rs
+++ b/components/epaxos/src/lib.rs
@@ -4,6 +4,9 @@
 extern crate quick_error;
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 pub mod testutil;
 
 pub mod conf;

--- a/components/epaxos/src/replica/replica.rs
+++ b/components/epaxos/src/replica/replica.rs
@@ -24,7 +24,9 @@ use crate::replica::ReplicaError;
 use crate::replication::RpcHandlerError;
 use crate::Iter;
 use crate::Storage;
+use std::sync::Arc;
 use storage::StorageError;
+use storage::WithNs;
 
 /// ref_or_bug extracts a immutable ref from an Option.
 /// If the Option is None a bug handler is triggered.
@@ -111,7 +113,7 @@ impl Replica {
             replica_id: rid,
             group_replica_ids: group.replicas.keys().cloned().collect(),
             peers,
-            storage: sto,
+            storage: Arc::new(WithNs::new(rid, sto)),
             // TODO get from conf
             committed_timeout: 10000,
         })

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -22,7 +22,7 @@ use crate::ServerError;
 
 /// Server impl some user protocol such as redis protocol and a replication service.
 pub struct Server {
-    server_data: Arc<ServerData>,
+    pub server_data: Arc<ServerData>,
     stop_txs: Vec<(&'static str, Sender<()>)>,
     join_handle: Vec<JoinHandle<()>>,
 }

--- a/tests/test_replica.rs
+++ b/tests/test_replica.rs
@@ -50,14 +50,19 @@ async fn _test_replica_exec_thread() {
         ),
     ];
 
+    // there is only replica
+
     for (inst, max) in cases.iter() {
-        ctx.storage.set_instance(&inst).unwrap();
-        ctx.storage.set_ref("max", 1, *max).unwrap();
-        //ctx.storage.set_ref("exec", 1, (1, 1).into()).unwrap();
+        let rid: ReplicaId = 1;
+
+        let sd = &ctx.server.server_data;
+        let r = sd.local_replicas.get(&rid).unwrap();
+        let sto = &r.storage;
+        sto.set_instance(&inst).unwrap();
+        sto.set_ref("max", 1, *max).unwrap();
 
         loop {
-            let inst1 = ctx
-                .storage
+            let inst1 = sto
                 .get_instance(inst.instance_id.unwrap())
                 .unwrap()
                 .unwrap();
@@ -69,7 +74,7 @@ async fn _test_replica_exec_thread() {
         }
 
         for cmd in inst.cmds.iter() {
-            let v = ctx.storage.get_kv(&cmd.key).unwrap().unwrap();
+            let v = sto.get_kv(&cmd.key).unwrap().unwrap();
             assert_eq!(v, cmd.value);
         }
     }

--- a/tests/test_setget.rs
+++ b/tests/test_setget.rs
@@ -33,7 +33,10 @@ async fn _test_set() {
     let mut con = ctx.client.get_connection().unwrap();
     redis::cmd("SET").arg("foo").arg(42).execute(&mut con);
 
-    let sto = ctx.storage;
+    let rid: ReplicaId = 1;
+    let sd = &ctx.server.server_data;
+    let r = sd.local_replicas.get(&rid).unwrap();
+    let sto = &r.storage;
     let inst = sto.get_instance((1, 0).into());
     println!("read inst: {:?}", inst);
 


### PR DESCRIPTION
### feat: Replica use namespaced storage to separate storage.

-   Generics in storage traits does not need to be `Sized`, so that it
    is able to accept a `dyn Storage` type.


### feat: ServerData now provides multiple predefined test cluster configs




## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
