### PR TITLE
Test 3 replica

### DIFF
--- a/components/epaxos/src/conf/conf.rs
+++ b/components/epaxos/src/conf/conf.rs
@@ -10,6 +10,45 @@ use crate::qpaxos::ReplicaId;
 
 use serde::{Deserialize, Serialize};
 
+/// LOCAL_NODE_ID is the only node id used in LOCAL_CLUSTERS.
+pub static LOCAL_NODE_ID: &str = "127.0.0.1:4441";
+
+lazy_static! {
+    /// LOCAL_CLUSTERS predefines several single-node cluster for testing.
+    static ref LOCAL_CLUSTERS: BTreeMap<&'static str, &'static str> = {
+        let mut h = BTreeMap::new();
+        h.insert("az_1", "
+nodes:
+    127.0.0.1:4441:
+        api_addr: 127.0.0.1:6379
+        replication: 127.0.0.1:4441
+groups:
+-   range:
+    -   a
+    -   z
+    replicas:
+        1: 127.0.0.1:4441
+");
+
+        h.insert("az_3", "
+nodes:
+    127.0.0.1:4441:
+        api_addr: 127.0.0.1:6379
+        replication: 127.0.0.1:4441
+groups:
+-   range:
+    -   a
+    -   z
+    replicas:
+        1: 127.0.0.1:4441
+        2: 127.0.0.1:4441
+        3: 127.0.0.1:4441
+");
+
+        h
+    };
+}
+
 /// NodeId is the global identity of a service.
 /// A physical server could have several node on it.
 /// A node has one or more Replica it serves for.
@@ -74,6 +113,16 @@ impl DerefMut for ClusterInfo {
 }
 
 impl ClusterInfo {
+    /// new_predefined creates a ClusterInfo with predefined config specified by `name`.
+    /// Such a cluster is only meant for test.
+    /// Available names are:
+    /// az_1: to create a cluster with 1 group of replica 1 covers key from `[a, z)`.
+    /// az_3: to create a cluster with 1 group of replica 1, 2, 3 covers key from `[a, z)`.
+    pub fn new_predefined(name: &str) -> Self {
+        let yaml = LOCAL_CLUSTERS[name];
+        ClusterInfo::from_str(yaml).unwrap()
+    }
+
     /// from_file read cluster conf yaml from a local file.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<ClusterInfo, ConfError> {
         let content = fs::read_to_string(path)?;

--- a/components/epaxos/src/qpaxos/display.rs
+++ b/components/epaxos/src/qpaxos/display.rs
@@ -21,7 +21,7 @@ use crate::qpaxos::ReplicateRequest;
 use crate::qpaxos::StorageFailure;
 use std::fmt;
 
-trait ToStringExt {
+pub trait ToStringExt {
     fn tostr_ext(&self) -> String;
 }
 

--- a/components/epaxos/src/qpaxos/errors.rs
+++ b/components/epaxos/src/qpaxos/errors.rs
@@ -12,6 +12,10 @@ quick_error! {
             display("lack of required field:{}", field)
         }
 
+        NotMatch(field: String, want: String, got: String) {
+            display("field: {} expect: {} but: {}", field, want, got)
+        }
+
         Incomplete(field: String, want: i32, actual: i32) {
             display("incomplete field:{}, need:{}, but:{}", field, want, actual)
         }
@@ -36,6 +40,16 @@ impl Into<QError> for ProtocolError {
                     field: f.clone(),
                     problem: "LackOf".into(),
                     ctx: "".into(),
+                }),
+                ..Default::default()
+            },
+
+            // TODO not InvalidRequest but InvalidReply
+            Self::NotMatch(f, _want, _got) => QError {
+                req: Some(InvalidRequest {
+                    field: f.clone(),
+                    problem: "NotMatch".into(),
+                    ctx,
                 }),
                 ..Default::default()
             },

--- a/components/epaxos/src/qpaxos/mod.rs
+++ b/components/epaxos/src/qpaxos/mod.rs
@@ -28,6 +28,7 @@ pub mod errors;
 pub mod quorums;
 
 pub use conflict::*;
+pub use display::*;
 pub use errors::*;
 pub use macros::*;
 pub use quorums::*;

--- a/components/epaxos/src/replication/replication.rs
+++ b/components/epaxos/src/replication/replication.rs
@@ -50,9 +50,11 @@ pub async fn replicate(
     let req = MakeRequest::fast_accept(0, &st.instance, &deps_committed);
     let repls = bcast_msg(&r.peers, req).await;
 
-    println!("fast-replies:{:?}", repls);
+    println!("got {} replies", repls.len());
 
     for (from_rid, repl) in repls.iter() {
+        println!("fast-reply from:{} {}", from_rid, repl.get_ref());
+        // TODO  consume repl do not clone
         handle_fast_accept_reply(&mut st, *from_rid, repl.get_ref().clone())?;
         let fast = st.get_fast_commit_deps(&grids);
         match fast {
@@ -87,7 +89,7 @@ pub async fn replicate(
     let repls = bcast_msg(&r.peers, req).await;
 
     for (from_rid, repl) in repls.iter() {
-        handle_accept_reply(&mut st, *from_rid, repl.get_ref())?;
+        handle_accept_reply(&mut st, *from_rid, repl.get_ref().clone())?;
         if st.accept_oks.len() as i32 >= st.quorum {
             // instance is safe to commit.
             return Ok(st);

--- a/components/epaxos/src/service/service.rs
+++ b/components/epaxos/src/service/service.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 use tonic;
 use tonic::{Request, Response, Status};
 
-#[derive(Default)]
 pub struct QPaxosImpl {
     server_data: Arc<ServerData>,
 }
@@ -26,9 +25,10 @@ impl QPaxos for QPaxosImpl {
         &self,
         request: Request<ReplicateRequest>,
     ) -> Result<Response<ReplicateReply>, Status> {
-        println!("Got a request: {:?}", request);
-
+        let _meta = request.metadata();
         let req = request.into_inner();
+
+        println!("Got a ReplicateRequest: {}", req);
 
         let reply = handle_replicate_request(self, req);
         let reply = match reply {

--- a/components/epaxos/src/testutil.rs
+++ b/components/epaxos/src/testutil.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::qpaxos::*;
 use crate::replica::{Replica, ReplicaPeer};
+use crate::serverdata::ServerData;
 use crate::QPaxosImpl;
 use crate::Storage;
 use storage::MemEngine;
@@ -149,7 +150,7 @@ impl TestCluster {
         for addr in self.addrs.iter() {
             let (tx, rx) = oneshot::channel::<()>();
 
-            let qp = QPaxosImpl::default();
+            let qp = QPaxosImpl::new(Arc::new(ServerData::new_inmem("az_1")));
             let s = Server::builder().add_service(QPaxosServer::new(qp));
 
             // remove scheme

--- a/components/epaxos/tests/test_repl_server.rs
+++ b/components/epaxos/tests/test_repl_server.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 
 use epaxos::qpaxos as qp;
 use epaxos::QPaxosImpl;
+use epaxos::ServerData;
+use std::sync::Arc;
 
 #[test]
 fn test_repl_server() {
@@ -23,7 +25,7 @@ async fn _repl_server() {
 
     // start a replication server in a coroutine
 
-    let qp = QPaxosImpl::default();
+    let qp = QPaxosImpl::new(Arc::new(ServerData::new_inmem("az_1")));
     let s = Server::builder().add_service(qp::QPaxosServer::new(qp));
 
     tokio::spawn(async move {

--- a/src/redisapi/redisapi.rs
+++ b/src/redisapi/redisapi.rs
@@ -101,7 +101,7 @@ impl RedisApi {
                 }
             };
             let r = self.exec_redis_cmd(v).await;
-            println!("r={:?}", r);
+            println!("exec_redis_cmd r={:?}", r);
             println!("response bytes:{:?}", r.as_bytes());
             sock.write_all(&*r.as_bytes())
                 .await

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -28,9 +28,18 @@ pub struct Server {
 }
 
 impl Server {
+    /// new_inmem creates a test cluster specified by name with only in-memory storage.
+    pub fn new_inmem(name: &str) -> Self {
+        Self::new_with_server_data(ServerData::new_inmem(name))
+    }
+
     pub fn new(sto: Storage, cluster: ClusterInfo, node_id: NodeId) -> Server {
+        Self::new_with_server_data(ServerData::new(sto, cluster, node_id))
+    }
+
+    pub fn new_with_server_data(sd: ServerData) -> Self {
         Server {
-            server_data: Arc::new(ServerData::new(sto, cluster, node_id)),
+            server_data: Arc::new(sd),
             stop_txs: Vec::new(),
             join_handle: Vec::new(),
         }
@@ -122,7 +131,7 @@ impl Server {
         println!("serving: {}", api_addr);
 
         // TODO load cluster conf
-        let qp = QPaxosImpl::default();
+        let qp = QPaxosImpl::new(sd);
         let s = tonic::transport::Server::builder().add_service(QPaxosServer::new(qp));
 
         let j2 = tokio::spawn(async move {

--- a/tests/test_replica.rs
+++ b/tests/test_replica.rs
@@ -19,7 +19,7 @@ fn test_replica_exec_thread() {
 
 #[tokio::main]
 async fn _test_replica_exec_thread() {
-    let ctx = InProcContext::new();
+    let ctx = InProcContext::new("az_1");
 
     let cases = [
         (
@@ -53,11 +53,7 @@ async fn _test_replica_exec_thread() {
     // there is only replica
 
     for (inst, max) in cases.iter() {
-        let rid: ReplicaId = 1;
-
-        let sd = &ctx.server.server_data;
-        let r = sd.local_replicas.get(&rid).unwrap();
-        let sto = &r.storage;
+        let sto = &ctx.get_replica(1).storage;
         sto.set_instance(&inst).unwrap();
         sto.set_ref("max", 1, *max).unwrap();
 


### PR DESCRIPTION
### test: test 3 replica group on a single node.

-   Move predefined test cluster config to mod conf.
    There are 2 cluster: az_1 has 1 replica, az_3 has 3 replicas.

-   Tests relies on a cluster use predefined cluster az_1 or az_3.
    And removed QPaxosImpl::default().

    In tests, checking shared storage changed to checking replica
    storage: a `WithNs`, which is Storage with namespace.

-   test: test_set: in a 3-replica cluster it checks fast-accept status
    for all 3 replcias.

-   Server adds new_inmem() to create a in-memory cluster for test.
    and new_with_server_data() to create a cluster from pre-built
    ServerData.

-   let check_repl_common do more common fields check for replies,
    includes: instance_id, phase, and stale ballot.

    From now on it allows last_ballot to be `None`, for replies from
    uninitialized instance has ballot of `None`.

-   Adjust tests according to field checking order changes.

-   refactor: when handling replies, consume reply object instead of
    using ref to it.

-   Test: test supporting mod InProcContext removes cluster conf from
    it and use the config defined in mod conf.


### feat: add ProtocolError::NotMatch() for unnmatched field value.




## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**
- **Test changes**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
