### PR TITLE
Refine testing

### DIFF
--- a/components/epaxos/src/conf/conf.rs
+++ b/components/epaxos/src/conf/conf.rs
@@ -10,45 +10,6 @@ use crate::qpaxos::ReplicaId;
 
 use serde::{Deserialize, Serialize};
 
-/// LOCAL_NODE_ID is the only node id used in LOCAL_CLUSTERS.
-pub static LOCAL_NODE_ID: &str = "127.0.0.1:4441";
-
-lazy_static! {
-    /// LOCAL_CLUSTERS predefines several single-node cluster for testing.
-    static ref LOCAL_CLUSTERS: BTreeMap<&'static str, &'static str> = {
-        let mut h = BTreeMap::new();
-        h.insert("az_1", "
-nodes:
-    127.0.0.1:4441:
-        api_addr: 127.0.0.1:6379
-        replication: 127.0.0.1:4441
-groups:
--   range:
-    -   a
-    -   z
-    replicas:
-        1: 127.0.0.1:4441
-");
-
-        h.insert("az_3", "
-nodes:
-    127.0.0.1:4441:
-        api_addr: 127.0.0.1:6379
-        replication: 127.0.0.1:4441
-groups:
--   range:
-    -   a
-    -   z
-    replicas:
-        1: 127.0.0.1:4441
-        2: 127.0.0.1:4441
-        3: 127.0.0.1:4441
-");
-
-        h
-    };
-}
-
 /// NodeId is the global identity of a service.
 /// A physical server could have several node on it.
 /// A node has one or more Replica it serves for.
@@ -113,16 +74,6 @@ impl DerefMut for ClusterInfo {
 }
 
 impl ClusterInfo {
-    /// new_predefined creates a ClusterInfo with predefined config specified by `name`.
-    /// Such a cluster is only meant for test.
-    /// Available names are:
-    /// az_1: to create a cluster with 1 group of replica 1 covers key from `[a, z)`.
-    /// az_3: to create a cluster with 1 group of replica 1, 2, 3 covers key from `[a, z)`.
-    pub fn new_predefined(name: &str) -> Self {
-        let yaml = LOCAL_CLUSTERS[name];
-        ClusterInfo::from_str(yaml).unwrap()
-    }
-
     /// from_file read cluster conf yaml from a local file.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<ClusterInfo, ConfError> {
         let content = fs::read_to_string(path)?;

--- a/components/epaxos/src/lib.rs
+++ b/components/epaxos/src/lib.rs
@@ -10,6 +10,7 @@ extern crate lazy_static;
 pub mod testutil;
 
 pub mod conf;
+mod iters;
 mod serverdata;
 mod service;
 
@@ -18,12 +19,11 @@ pub mod qpaxos;
 pub mod replica;
 pub mod replication;
 
+pub use conf::*;
+pub use iters::*;
 pub use replication::*;
 pub use serverdata::*;
 pub use service::*;
-
-mod iters;
-pub use iters::*;
 
 use qpaxos::*;
 use std::sync::Arc;

--- a/components/epaxos/src/qpaxos/test_command.rs
+++ b/components/epaxos/src/qpaxos/test_command.rs
@@ -36,30 +36,47 @@ fn test_command_conflit() {
     let nx = Command::from(("NoOp", "x", "1"));
     let gx = Command::from(("Get", "x", "1"));
     let sx = Command::from(("Set", "x", "1"));
+    let dx = Command::from(("Delete", "x", "1"));
 
     let ny = Command::from(("NoOp", "y", "1"));
     let gy = Command::from(("Get", "y", "1"));
     let sy = Command::from(("Set", "y", "1"));
+    let dy = Command::from(("Delete", "y", "1"));
 
-    assert!(!nx.conflict(&nx));
-    assert!(!nx.conflict(&gx));
-    assert!(!nx.conflict(&sx));
+    let xs = vec![nx, gx, sx, dx];
+    let ys = vec![ny, gy, sy, dy];
 
-    assert!(!gx.conflict(&nx));
-    assert!(!gx.conflict(&gx));
-    assert!(gx.conflict(&sx));
+    // conflicts[i, j] indicates whether xs[i] and xs[j] conflict.
+    let conflicts = vec![
+        vec![0, 0, 0, 0],
+        vec![0, 0, 1, 1],
+        vec![0, 1, 1, 1],
+        vec![0, 1, 1, 1],
+    ];
 
-    assert!(!sx.conflict(&nx));
-    assert!(sx.conflict(&gx));
-    assert!(sx.conflict(&sx));
+    for (i, v) in conflicts.iter().enumerate() {
+        for (j, c) in v.iter().enumerate() {
+            let want = *c == 1;
 
-    assert!(!sx.conflict(&ny));
-    assert!(!sx.conflict(&gy));
-    assert!(!sx.conflict(&sy));
+            assert_eq!(
+                want,
+                xs[i].conflict(&xs[j]),
+                "x x check conflict: {} {}",
+                i,
+                j
+            );
+            assert_eq!(
+                want,
+                ys[i].conflict(&ys[j]),
+                "y y check conflict: {} {}",
+                i,
+                j
+            );
 
-    assert!(!sy.conflict(&nx));
-    assert!(!sy.conflict(&gx));
-    assert!(!sy.conflict(&sx));
+            assert!(!xs[i].conflict(&ys[j]), "x y never conflict: {} {}", i, j);
+            assert!(!ys[i].conflict(&xs[j]), "y x never conflict: {} {}", i, j);
+        }
+    }
 }
 
 #[test]

--- a/components/epaxos/src/serverdata/serverdata.rs
+++ b/components/epaxos/src/serverdata/serverdata.rs
@@ -1,4 +1,3 @@
-use crate::conf;
 use crate::conf::ClusterInfo;
 use crate::conf::GroupInfo;
 use crate::conf::Node;
@@ -8,8 +7,6 @@ use crate::replica::Replica;
 use crate::RangeLookupError;
 use crate::Storage;
 use std::collections::BTreeMap;
-use std::sync::Arc;
-use storage::MemEngine;
 
 /// ServerData is shared between threads or coroutine.
 /// TODO: Storage does not need to be shared with Arc any more.
@@ -23,21 +20,6 @@ pub struct ServerData {
 }
 
 impl ServerData {
-    /// new_inmem creates a ServerData with predefined config specified by `name`. See
-    /// ClusterInfo::new_predefined.
-    ///
-    /// Such a cluster is only meant for test because it use a in-memory storage.
-    pub fn new_inmem(name: &str) -> ServerData {
-        let ci = ClusterInfo::new_predefined(name);
-
-        let sto = MemEngine::new().unwrap();
-        let sto = Arc::new(sto);
-
-        let node_id = conf::LOCAL_NODE_ID;
-
-        ServerData::new(sto, ci, node_id.into())
-    }
-
     pub fn new(sto: Storage, cluster: ClusterInfo, node_id: NodeId) -> ServerData {
         let n = cluster.get(&node_id).unwrap().clone();
 

--- a/components/epaxos/src/testutil.rs
+++ b/components/epaxos/src/testutil.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use crate::qpaxos::*;
 use crate::replica::{Replica, ReplicaPeer};
-use crate::serverdata::ServerData;
 use crate::QPaxosImpl;
 use crate::Storage;
 use storage::MemEngine;
@@ -12,6 +11,11 @@ use storage::MemEngine;
 use tokio::sync::oneshot;
 use tokio::time::delay_for;
 use tonic::transport::Server;
+
+#[path = "testutil_cluster.rs"]
+mod testutil_cluster;
+
+pub use testutil_cluster::*;
 
 /// Create an instance with command "set x=y".
 /// Use this when only deps are concerned.
@@ -150,7 +154,7 @@ impl TestCluster {
         for addr in self.addrs.iter() {
             let (tx, rx) = oneshot::channel::<()>();
 
-            let qp = QPaxosImpl::new(Arc::new(ServerData::new_inmem("az_1")));
+            let qp = QPaxosImpl::new(Arc::new(new_inmem_server_data("az_1")));
             let s = Server::builder().add_service(QPaxosServer::new(qp));
 
             // remove scheme

--- a/components/epaxos/src/testutil_cluster.rs
+++ b/components/epaxos/src/testutil_cluster.rs
@@ -1,0 +1,68 @@
+use crate::ClusterInfo;
+use crate::NodeId;
+use crate::ServerData;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use storage::MemEngine;
+
+lazy_static! {
+    /// LOCAL_CLUSTERS predefines several single-node cluster for testing.
+    static ref LOCAL_CLUSTERS: BTreeMap<&'static str, &'static str> = {
+        let mut h = BTreeMap::new();
+        h.insert("az_1", "
+nodes:
+    127.0.0.1:4441:
+        api_addr: 127.0.0.1:6379
+        replication: 127.0.0.1:4441
+groups:
+-   range:
+    -   a
+    -   z
+    replicas:
+        1: 127.0.0.1:4441
+");
+
+        h.insert("az_3", "
+nodes:
+    127.0.0.1:4441:
+        api_addr: 127.0.0.1:6379
+        replication: 127.0.0.1:4441
+groups:
+-   range:
+    -   a
+    -   z
+    replicas:
+        1: 127.0.0.1:4441
+        2: 127.0.0.1:4441
+        3: 127.0.0.1:4441
+");
+
+        h
+    };
+}
+
+/// new_cluster creates a ClusterInfo with predefined config specified by `name`.
+/// Such a cluster is only meant for test.
+/// Available names are:
+/// az_1: to create a cluster with 1 group of replica 1 covers key from `[a, z)`.
+/// az_3: to create a cluster with 1 group of replica 1, 2, 3 covers key from `[a, z)`.
+pub fn new_cluster(name: &str) -> ClusterInfo {
+    let yaml = LOCAL_CLUSTERS[name];
+    ClusterInfo::from_str(yaml).unwrap()
+}
+
+/// new_inmem_server_data creates a ServerData with predefined config specified by `name`. See
+/// ClusterInfo::new_predefined.
+///
+/// Such a cluster is only meant for test because it use a in-memory storage.
+pub fn new_inmem_server_data(name: &str) -> ServerData {
+    let ci = new_cluster(name);
+
+    let sto = MemEngine::new().unwrap();
+    let sto = Arc::new(sto);
+
+    let node_ids: Vec<NodeId> = ci.nodes.keys().cloned().collect();
+    let node_id: NodeId = node_ids[0].clone();
+
+    ServerData::new(sto, ci, node_id)
+}

--- a/components/epaxos/tests/test_repl_server.rs
+++ b/components/epaxos/tests/test_repl_server.rs
@@ -7,8 +7,8 @@ use tokio::time::delay_for;
 use std::time::Duration;
 
 use epaxos::qpaxos as qp;
+use epaxos::testutil;
 use epaxos::QPaxosImpl;
-use epaxos::ServerData;
 use std::sync::Arc;
 
 #[test]
@@ -25,7 +25,7 @@ async fn _repl_server() {
 
     // start a replication server in a coroutine
 
-    let qp = QPaxosImpl::new(Arc::new(ServerData::new_inmem("az_1")));
+    let qp = QPaxosImpl::new(Arc::new(testutil::new_inmem_server_data("az_1")));
     let s = Server::builder().add_service(qp::QPaxosServer::new(qp));
 
     tokio::spawn(async move {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -28,11 +28,6 @@ pub struct Server {
 }
 
 impl Server {
-    /// new_inmem creates a test cluster specified by name with only in-memory storage.
-    pub fn new_inmem(name: &str) -> Self {
-        Self::new_with_server_data(ServerData::new_inmem(name))
-    }
-
     pub fn new(sto: Storage, cluster: ClusterInfo, node_id: NodeId) -> Server {
         Self::new_with_server_data(ServerData::new(sto, cluster, node_id))
     }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -19,6 +19,7 @@ use redis::RedisResult;
 use cele::Server;
 use epaxos::qpaxos::ReplicaId;
 use epaxos::replica::Replica;
+use epaxos::testutil;
 use epaxos::Storage;
 
 /// InProcContext setup a small cluster of an in-process server and a client.
@@ -36,7 +37,8 @@ impl InProcContext {
     }
 
     pub fn new(conf_name: &str) -> Self {
-        let mut server = Server::new_inmem(conf_name);
+        let sd = testutil::new_inmem_server_data(conf_name);
+        let mut server = Server::new_with_server_data(sd);
         let sto = server.server_data.storage.clone();
         server.start();
 


### PR DESCRIPTION
### feat: add testutil::wait_for() as a general impl waiting for server setting up listening


### refactor: move testing cluster info config into testutil.

-   Remove LOCAL_NODE_ID. load node id from cluster config instead.


### feat: add Command::kind() to get kind of a command.

-   kind() is one of there: NoOp, Get and Set. Delete is a Set kind
    command.

-   refactor: rewrite Command::conflict with Command::kind().

-   refactor: test of Command::conflict() with a matrix of expected
    confliction.




## Type of change       <!-- delete irrelevant options. -->

- **New feature**       <!-- non-breaking change which adds functionality -->
- **Refactoring**
- **Test changes**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
