### PR TITLE
feat: removes ref:max from storage. A replica does not need to track max-instance-id to work well.

### DIFF
--- a/components/epaxos/src/replica/exec.rs
+++ b/components/epaxos/src/replica/exec.rs
@@ -237,18 +237,11 @@ impl Replica {
         let mut smallest_inst_ids = InstanceIdVec::from([0; 0]);
         for rid in self.group_replica_ids.iter() {
             let exec_iid = self.storage.get_ref("exec", *rid)?;
-            let max_iid = self.storage.get_ref("max", *rid)?;
-            if let None = max_iid {
-                continue;
-            }
-
             let exec_iid = exec_iid.unwrap_or((*rid, -1).into());
-            let max_iid = max_iid.unwrap();
 
             exec_up_to.push(exec_iid);
-            if exec_iid < max_iid {
-                smallest_inst_ids.push((*rid, exec_iid.idx + 1).into());
-            }
+
+            smallest_inst_ids.push((*rid, exec_iid.idx + 1).into());
         }
 
         let instances = self.get_insts_if_committed(&smallest_inst_ids)?;

--- a/components/epaxos/src/replica/test_exec.rs
+++ b/components/epaxos/src/replica/test_exec.rs
@@ -254,7 +254,6 @@ fn test_replica_execute() {
         // (1, 1)
         (
             vec![test_inst!((1, 1), [(1, 0), (2, 0), (3, 0)], true)],
-            vec![(1, 1), (2, 0), (3, 0)],
             vec![(1, 0), (2, 0), (3, 0)],
             vec![InstanceId::from((1, 1))],
         ),
@@ -265,7 +264,6 @@ fn test_replica_execute() {
                 test_inst!((2, 2), [(1, 2), (2, 1), (3, 1)], true),
                 test_inst!((3, 2), [(1, 2), (2, 2), (3, 1)], true),
             ],
-            vec![(1, 2), (2, 2), (3, 2)],
             vec![(1, 1), (2, 1), (3, 1)],
             vec![InstanceId::from((1, 2))],
         ),
@@ -276,7 +274,6 @@ fn test_replica_execute() {
                 test_inst!((2, 3), [(1, 3), (2, 2), (3, 2)], true),
                 test_inst!((3, 3), [(1, 3), (2, 2), (3, 2)], true),
             ],
-            vec![(1, 3), (2, 3), (3, 3)],
             vec![(1, 2), (2, 2), (3, 2)],
             vec![InstanceId::from((1, 3)), (2, 3).into(), (3, 3).into()],
         ),
@@ -287,7 +284,6 @@ fn test_replica_execute() {
                 test_inst!((2, 4), [(1, 3), (2, 3), (3, 4)], true),
                 test_inst!((3, 4), [(1, 4), (2, 4), (3, 3)], true),
             ],
-            vec![(1, 4), (2, 4), (3, 4)],
             vec![(1, 3), (2, 3), (3, 3)],
             vec![InstanceId::from((2, 4))],
         ),
@@ -297,22 +293,16 @@ fn test_replica_execute() {
                 test_inst!((2, 5), [(1, 5), (2, 4), (3, 5)], true),
                 test_inst!((3, 5), [(1, 4), (2, 5), (3, 4)], true),
             ],
-            vec![(1, 4), (2, 5), (3, 5)],
             vec![(1, 4), (2, 4), (3, 4)],
             Vec::<InstanceId>::new(),
         ),
     ];
 
-    for (insts, max_ref, exec_ref, rst) in cases.iter() {
+    for (insts, exec_ref, rst) in cases.iter() {
         insts.iter().for_each(|inst| {
             rp.storage.set_instance(&inst).unwrap();
         });
 
-        for (rid, idx) in max_ref.iter() {
-            rp.storage
-                .set_ref("max", *rid as i64, (*rid as i64, *idx as i64).into())
-                .unwrap();
-        }
         for (rid, idx) in exec_ref.iter() {
             rp.storage
                 .set_ref("exec", *rid as i64, (*rid as i64, *idx as i64).into())

--- a/components/storage/src/test_engine.rs
+++ b/components/storage/src/test_engine.rs
@@ -188,11 +188,6 @@ where
     for (k, v) in cases {
         let v = TestId { id: v };
 
-        eng.set_ref("max", k, v).unwrap();
-        let act = eng.get_ref("max", k).unwrap().unwrap();
-
-        assert_eq!(act, v);
-
         eng.set_ref("exec", k, v).unwrap();
         let act = eng.get_ref("exec", k).unwrap().unwrap();
 

--- a/components/storage/src/traits.rs
+++ b/components/storage/src/traits.rs
@@ -191,9 +191,8 @@ where
     T: LowerHex,
 {
     match typ {
-        "max" => format!("/status/max_instance_id/{:016x}", id).into_bytes(),
         "exec" => format!("/status/max_exec_instance_id/{:016x}", id).into_bytes(),
-        _ => panic!("unknown type ref"),
+        _ => panic!("unknown type ref: {}", typ),
     }
 }
 

--- a/tests/test_replica.rs
+++ b/tests/test_replica.rs
@@ -22,40 +22,33 @@ async fn _test_replica_exec_thread() {
     let ctx = InProcContext::new("az_1");
 
     let cases = [
-        (
-            inst!(
-                (1, 0),
-                (3, 4, 2),
-                [("Set", "x", "y")],
-                [(1, 0)],
-                [(1, 0)],
-                [(1, 0)],
-                true,
-                false,
-            ),
-            InstanceId::from((1, 0)),
+        inst!(
+            (1, 0),
+            (3, 4, 2),
+            [("Set", "x", "y")],
+            [(1, 0)],
+            [(1, 0)],
+            [(1, 0)],
+            true,
+            false,
         ),
-        (
-            inst!(
-                (1, 1),
-                (3, 4, 2),
-                [("Set", "z", "a")],
-                [(1, 0)],
-                [(1, 0)],
-                [(1, 0)],
-                true,
-                false,
-            ),
-            InstanceId::from((1, 1)),
+        inst!(
+            (1, 1),
+            (3, 4, 2),
+            [("Set", "z", "a")],
+            [(1, 0)],
+            [(1, 0)],
+            [(1, 0)],
+            true,
+            false,
         ),
     ];
 
     // there is only replica
 
-    for (inst, max) in cases.iter() {
+    for inst in cases.iter() {
         let sto = &ctx.get_replica(1).storage;
         sto.set_instance(&inst).unwrap();
-        sto.set_ref("max", 1, *max).unwrap();
 
         loop {
             let inst1 = sto


### PR DESCRIPTION
### feat: removes ref:max from storage. A replica does not need to track max-instance-id to work well.

## Type of change       <!-- delete irrelevant options. -->

- **Refactoring**
- **Test changes**

# Checklist:

- [x] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
